### PR TITLE
Migrating to JUnit 5 and replacing JUnit assertions with the AssertJ library

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,5 @@
 # Este workflow de GitHub Actions automatiza el proceso de integracion continua (CI) para un proyecto Maven de Java. Se 
-# ejecuta automaticamente cada vez que se hace push o pull request a la rama main, realizando una secuencia  de pasos 
+# ejecuta automaticamente cada vez que se hace push o pull request a la rama main, realizando una secuencia de pasos
 # esenciales: primero configura el entorno con Java 17, luego compila y empaqueta el proyecto en un JAR usando Maven, 
 # despues ejecuta todas las pruebas unitarias y genera reportes de cobertura de codigo con JaCoCo que se envian a 
 # Coveralls para su visualizacion, y finalmente actualiza el grafo de dependencias en GitHub para habilitar las alertas

--- a/pom.xml
+++ b/pom.xml
@@ -11,30 +11,47 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>Argentum Online Server</name>
-    <description>AO Server - Java implementation of Argentum Online server</description>
+    <name>AO Server</name>
+    <description>Server implementation for Argentum Online</description>
+
+    <issueManagement>
+        <system>Github Issue Tracker</system>
+        <url>https://github.com/ao-server/issues</url>
+    </issueManagement>
+
+    <modules>
+        <module>server</module>
+        <module>server-security</module>
+    </modules>
 
     <properties>
-        <!-- Encoding -->
+        <!-- Build configuration -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <!-- Java version -->
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <java.version>17</java.version>
-        <!-- Dependencies versions -->
-        <logback.version>1.5.13</logback.version>
-        <slf4j.version>2.0.9</slf4j.version>
-        <junit.version>5.10.1</junit.version>
-        <junit4.version>4.13.2</junit4.version>
-        <ini4j.version>0.5.4</ini4j.version>
+
+        <!-- Core dependencies versions -->
+        <netty.version>4.1.119.Final</netty.version>
         <guice.version>7.0.0</guice.version>
         <guava.version>32.0.1-jre</guava.version>
-        <netty.version>4.1.119.Final</netty.version>
-        <mockito.version>5.8.0</mockito.version>
-        <commons.validator.version>1.8.0</commons.validator.version>
+
+        <!-- Logging dependencies versions -->
+        <logback.version>1.5.13</logback.version>
+        <slf4j.version>2.0.9</slf4j.version>
+
+        <!-- Testing dependencies versions -->
+        <junit.version>5.13.4</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
+        <assertj.version>3.27.3</assertj.version>
+        <mockito.version>5.8.0</mockito.version>
+
+        <!-- Utility dependencies versions -->
+        <ini4j.version>0.5.4</ini4j.version>
+        <commons.validator.version>1.8.0</commons.validator.version>
         <oro.version>2.0.8</oro.version>
+
         <!-- Plugin versions -->
         <maven.compiler.plugin.version>3.11.0</maven.compiler.plugin.version>
         <maven.surefire.plugin.version>3.2.3</maven.surefire.plugin.version>
@@ -42,25 +59,26 @@
         <jacoco.plugin.version>0.8.11</jacoco.plugin.version>
     </properties>
 
-    <issueManagement>
-        <system>Github Issue Tracker</system>
-        <url>https://github.com/ao-server/issues</url>
-    </issueManagement>
-
-    <!-- Dependencias gestionadas para todos los modulos -->
     <dependencyManagement>
         <dependencies>
+            <!-- Core frameworks -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
                 <version>${guice.version}</version>
             </dependency>
-            <!-- Forzar version segura de Guava (soluciona CVE-2023-2976) -->
+            <!-- Guava (solves CVE-2023-2976) -->
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
             </dependency>
+
             <!-- Logging -->
             <dependency>
                 <groupId>ch.qos.logback</groupId>
@@ -77,28 +95,46 @@
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
-            <!-- Testing - JUnit 5 -->
+
+            <!-- Utilities -->
+            <dependency>
+                <groupId>org.ini4j</groupId>
+                <artifactId>ini4j</artifactId>
+                <version>${ini4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-validator</groupId>
+                <artifactId>commons-validator</artifactId>
+                <version>${commons.validator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>oro</groupId>
+                <artifactId>oro</artifactId>
+                <version>${oro.version}</version>
+            </dependency>
+
+            <!-- Testing frameworks -->
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
+                <!-- Dependencia agregada (BOM) que incluye APIs principales (junit-jupiter-api), motor de ejecucion (junit-jupiter-engine) y tests parametrizados (junit-jupiter-params) -->
                 <artifactId>junit-jupiter</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
-            <!-- Testing - JUnit 4 (para compatibilidad) -->
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit4.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <!-- Testing - Hamcrest (dependencia principal moderna) -->
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>
                 <version>${hamcrest.version}</version>
                 <scope>test</scope>
             </dependency>
-            <!-- Mockito -->
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <!-- Testing - Mockito -->
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
@@ -111,35 +147,13 @@
                 <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
-            <!-- Networking -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-all</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <!-- Utilidades -->
-            <dependency>
-                <groupId>org.ini4j</groupId>
-                <artifactId>ini4j</artifactId>
-                <version>${ini4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-validator</groupId>
-                <artifactId>commons-validator</artifactId>
-                <version>${commons.validator.version}</version>
-            </dependency>
-            <!-- Apache Oro (expresiones regulares) -->
-            <dependency>
-                <groupId>oro</groupId>
-                <artifactId>oro</artifactId>
-                <version>${oro.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <build>
         <pluginManagement>
             <plugins>
+                <!-- Core plugins -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -150,30 +164,37 @@
                         <encoding>${project.build.sourceEncoding}</encoding>
                     </configuration>
                 </plugin>
+
+                <!-- Testing plugins -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.plugin.version}</version>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>${maven.assembly.plugin.version}</version>
-                </plugin>
+
+                <!-- Quality plugins -->
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${jacoco.plugin.version}</version>
                 </plugin>
+
+                <!-- Packaging plugins -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${maven.assembly.plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
-            <!-- Configuracion del compilador -->
+            <!-- Compiler configuration -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+
             <!-- Test coverage -->
             <plugin>
                 <groupId>org.jacoco</groupId>
@@ -189,11 +210,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <!-- Modulos del proyecto -->
-    <modules>
-        <module>server</module>
-        <module>server-security</module>
-    </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,6 @@
 
         <!-- Testing dependencies versions -->
         <junit.version>5.13.4</junit.version>
-        <hamcrest.version>2.2</hamcrest.version>
         <assertj.version>3.27.3</assertj.version>
         <mockito.version>5.8.0</mockito.version>
 
@@ -119,12 +118,6 @@
                 <!-- Dependencia agregada (BOM) que incluye APIs principales (junit-jupiter-api), motor de ejecucion (junit-jupiter-engine) y tests parametrizados (junit-jupiter-params) -->
                 <artifactId>junit-jupiter</artifactId>
                 <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest</artifactId>
-                <version>${hamcrest.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/server-security/pom.xml
+++ b/server-security/pom.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
 
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <artifactId>aoserver</artifactId>
         <groupId>com.ao</groupId>
+        <artifactId>aoserver</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>server-security</artifactId>
 
-    <description>Security module for AO Server</description>
+    <name>Server Security</name>
+    <description>Security server module for Argentum Online</description>
 
     <dependencies>
         <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1,20 +1,89 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
 
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <artifactId>aoserver</artifactId>
         <groupId>com.ao</groupId>
+        <artifactId>aoserver</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>server</artifactId>
+
+    <name>Server Core</name>
+    <description>Core server module for Argentum Online</description>
+
+    <dependencies>
+        <!-- Core frameworks -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+        </dependency>
+
+        <!-- Utilities -->
+        <dependency>
+            <groupId>org.ini4j</groupId>
+            <artifactId>ini4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>oro</groupId>
+            <artifactId>oro</artifactId>
+        </dependency>
+
+        <!-- Internal modules -->
+        <dependency>
+            <groupId>com.ao</groupId>
+            <artifactId>server-security</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Testing frameworks -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+
+        <!-- Testing - Mocking -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
+            <!-- Packaging plugin -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.3</version>
+                <!-- Version inherited from parent pluginManagement -->
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -37,62 +106,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <dependencies>
-        <!-- Testing - JUnit 4 -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <!-- Testing - Hamcrest (CORREGIDO: solo esta dependencia) -->
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-        </dependency>
-        <!-- Logging -->
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-        </dependency>
-        <!-- Utilidades -->
-        <dependency>
-            <groupId>org.ini4j</groupId>
-            <artifactId>ini4j</artifactId>
-        </dependency>
-        <!-- Networking -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-        </dependency>
-        <!-- Testing - Mockito -->
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <!-- Validacion -->
-        <dependency>
-            <groupId>commons-validator</groupId>
-            <artifactId>commons-validator</artifactId>
-        </dependency>
-        <!-- Expresiones regulares -->
-        <dependency>
-            <groupId>oro</groupId>
-            <artifactId>oro</artifactId>
-        </dependency>
-        <!-- Proyecto hermano -->
-        <dependency>
-            <groupId>com.ao</groupId>
-            <artifactId>server-security</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
-    </dependencies>
 
 </project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -62,10 +62,6 @@
             <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>

--- a/server/src/main/java/com/ao/config/ini/ArchetypeConfigurationIni.java
+++ b/server/src/main/java/com/ao/config/ini/ArchetypeConfigurationIni.java
@@ -1,122 +1,117 @@
 package com.ao.config.ini;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-
-import com.google.inject.Inject;
-import com.google.inject.name.Named;
-
-import org.ini4j.Ini;
-import org.ini4j.InvalidFileFormatException;
-
 import com.ao.config.ArchetypeConfiguration;
 import com.ao.model.character.archetype.Archetype;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import org.ini4j.Ini;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 
 public class ArchetypeConfigurationIni implements ArchetypeConfiguration {
 
-	private static final String BLOCK_POWER_HEADER = "MODESCUDO";
-	private static final String EVASION_HEADER = "MODEVASION";
-	private static final String MELEE_ACCURACY_HEADER = "MODATAQUEARMAS";
-	private static final String MELEE_DAMAGE_HEADER = "MODDAÑOARMAS";
-	private static final String RANGED_ACCURACY_HEADER = "MODATAQUEPROYECTILES";
-	private static final String RANGED_DAMAGE_HEADER = "MODDAÑOPROYECTILES";
-	private static final String WRESTLING_DAMAGE_HEADER = "MODDAÑOWRESTLING";
+    private static final String BLOCK_POWER_HEADER = "MODESCUDO";
+    private static final String EVASION_HEADER = "MODEVASION";
+    private static final String MELEE_ACCURACY_HEADER = "MODATAQUEARMAS";
+    private static final String MELEE_DAMAGE_HEADER = "MODDAÑOARMAS";
+    private static final String RANGED_ACCURACY_HEADER = "MODATAQUEPROYECTILES";
+    private static final String RANGED_DAMAGE_HEADER = "MODDAÑOPROYECTILES";
+    private static final String WRESTLING_DAMAGE_HEADER = "MODDAÑOWRESTLING";
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArchetypeConfigurationIni.class);
+    private final Ini config;
 
-	private Ini config;
+    /**
+     * Constructor loads the configuration file.
+     * <p>
+     * Without DI (Dependency Injection), it is manual: new ArchetypeConfigurationIni("Dat/Balance.dat")
+     * <p>
+     * With DI, is automatic: @Inject ArchetypeConfigurationIni confi
+     */
+    @Inject
+    public ArchetypeConfigurationIni(@Named("ArchetypeConfigIni") String archetypeConfigIni) {
+        // Load from a classpath using try-with-resources for automatic resource management
+        InputStream inputStream = getClass().getClassLoader().getResourceAsStream(archetypeConfigIni);
+        if (inputStream == null)
+            throw new IllegalArgumentException("The file " + archetypeConfigIni + " was not found in the classpath");
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+            config = new Ini(reader);
+        } catch (Exception e) {
+            LOGGER.error("Archetype configuration loading failed for file: {}", archetypeConfigIni, e);
+            throw new RuntimeException("Failed to load archetype configuration", e);
+        }
+    }
 
-	/**
-	 * Constructor, loads the configuration file.
-	 * @throws InvalidFileFormatException
-	 * @throws FileNotFoundException
-	 * @throws IOException
-	 */
-	@Inject
-	public ArchetypeConfigurationIni(@Named("ArchetypeConfigIni") String archetypeConfigIni) throws IOException {
-		config = new Ini(new FileInputStream(archetypeConfigIni));
-	}
+    @Override
+    public float getBlockPowerModifier(Class<? extends Archetype> archetype) {
+        return Float.valueOf(config.get(BLOCK_POWER_HEADER).get(getArchetypeName(archetype)));
+    }
 
-	/**
-	 * Retrieves the archetype's name in the configuration file.
-	 * @param archetype The archetype.
-	 * @return The archetype's name.
-	 */
-	private String getArchetypeName(Class<? extends Archetype> archetype) {
+    @Override
+    public float getEvasionModifier(Class<? extends Archetype> archetype) {
+        return Float.valueOf(config.get(EVASION_HEADER).get(getArchetypeName(archetype)));
+    }
 
-		// Intended to be compatible with current INI files.... not the nicest thing ever...
-		String archetypeName = archetype.getSimpleName().replace( "Archetype", "");
+    @Override
+    public float getMeleeAccuracyModifier(Class<? extends Archetype> archetype) {
+        return Float.valueOf(config.get(MELEE_ACCURACY_HEADER).get(getArchetypeName(archetype)));
+    }
 
-		if (archetypeName.equals("Bard")) {
-			return "Bardo";
-		} else if (archetypeName.equals("Cleric")) {
-			return "Clerigo";
-		} else if (archetypeName.equals("Druid")) {
-			return "Druida";
-		} else if (archetypeName.equals("Fisher")) {
-			return "Pescador";
-		} else if (archetypeName.equals("Lumberjack")) {
-			return "Leñador";
-		} else if (archetypeName.equals("Mage")) {
-			return "Mago";
-		} else if (archetypeName.equals("Warrior")) {
-			return "Guerrero";
-		} else if (archetypeName.equals("Assasin")) {
-			return "Asesino";
-		} else if (archetypeName.equals("Thief")) {
-			return "Ladron";
-		} else if (archetypeName.equals("Bandit")) {
-			return "Bandido";
-		} else if (archetypeName.equals("Paladin")) {
-			return "Paladin";
-		} else if (archetypeName.equals("Hunter")) {
-			return "Cazador";
-		} else if (archetypeName.equals("Blacksmith")) {
-			return "Herrero";
-		} else if (archetypeName.equals("Carpenter")) {
-			return "Carpintero";
-		} else if (archetypeName.equals("Miner")) {
-			return "Minero";
-		} else if (archetypeName.equals("Pirate")) {
-			return "Pirata";
-		} else if (archetypeName.equals("Worker")) {
-			return "Trabajador";
-		}
+    @Override
+    public float getMeleeDamageModifier(Class<? extends Archetype> archetype) {
+        return Float.valueOf(config.get(MELEE_DAMAGE_HEADER).get(getArchetypeName(archetype)));
+    }
 
-		return null;
-	}
+    @Override
+    public float getRangedAccuracyModifier(Class<? extends Archetype> archetype) {
+        return Float.valueOf(config.get(RANGED_ACCURACY_HEADER).get(getArchetypeName(archetype)));
+    }
 
-	@Override
-	public float getBlockPowerModifier(Class<? extends Archetype> archetype) {
-		return Float.valueOf(config.get(BLOCK_POWER_HEADER).get(getArchetypeName(archetype)));
-	}
+    @Override
+    public float getRangedDamageModifier(Class<? extends Archetype> archetype) {
+        return Float.valueOf(config.get(RANGED_DAMAGE_HEADER).get(getArchetypeName(archetype)));
+    }
 
-	@Override
-	public float getEvasionModifier(Class<? extends Archetype> archetype) {
-		return Float.valueOf(config.get(EVASION_HEADER).get(getArchetypeName(archetype)));
-	}
+    @Override
+    public float getWrestlingDamageModifier(Class<? extends Archetype> archetype) {
+        return Float.valueOf(config.get(WRESTLING_DAMAGE_HEADER).get(getArchetypeName(archetype)));
+    }
 
-	@Override
-	public float getMeleeAccuracyModifier(Class<? extends Archetype> archetype) {
-		return Float.valueOf(config.get(MELEE_ACCURACY_HEADER).get(getArchetypeName(archetype)));
-	}
+    /**
+     * Retrieves the archetype's name in the configuration file.
+     *
+     * @param archetype archetype
+     * @return the archetype's name
+     */
+    private String getArchetypeName(Class<? extends Archetype> archetype) {
 
-	@Override
-	public float getMeleeDamageModifier(Class<? extends Archetype> archetype) {
-		return Float.valueOf(config.get(MELEE_DAMAGE_HEADER).get(getArchetypeName(archetype)));
-	}
+        // Intended to be compatible with current INI files... not the nicest thing ever...
+        String archetypeName = archetype.getSimpleName().replace("Archetype", "");
 
-	@Override
-	public float getRangedAccuracyModifier(Class<? extends Archetype> archetype) {
-		return Float.valueOf(config.get(RANGED_ACCURACY_HEADER).get(getArchetypeName(archetype)));
-	}
+        return switch (archetypeName) {
+            case "Bard" -> "Bardo";
+            case "Cleric" -> "Clerigo";
+            case "Druid" -> "Druida";
+            case "Fisher" -> "Pescador";
+            case "Lumberjack" -> "Leñador";
+            case "Mage" -> "Mago";
+            case "Warrior" -> "Guerrero";
+            case "Assasin" -> "Asesino";
+            case "Thief" -> "Ladron";
+            case "Bandit" -> "Bandido";
+            case "Paladin" -> "Paladin";
+            case "Hunter" -> "Cazador";
+            case "Blacksmith" -> "Herrero";
+            case "Carpenter" -> "Carpintero";
+            case "Miner" -> "Minero";
+            case "Pirate" -> "Pirata";
+            case "Worker" -> "Trabajador";
+            default -> null;
+        };
 
-	@Override
-	public float getRangedDamageModifier(Class<? extends Archetype> archetype) {
-		return Float.valueOf(config.get(RANGED_DAMAGE_HEADER).get(getArchetypeName(archetype)));
-	}
+    }
 
-	@Override
-	public float getWrestlingDamageModifier(Class<? extends Archetype> archetype) {
-		return Float.valueOf(config.get(WRESTLING_DAMAGE_HEADER).get(getArchetypeName(archetype)));
-	}
 }

--- a/server/src/main/java/com/ao/context/ApplicationContext.java
+++ b/server/src/main/java/com/ao/context/ApplicationContext.java
@@ -20,9 +20,9 @@ public class ApplicationContext {
     /**
      * Retrieves an instance of the requested class.
      *
-     * @param <T>   Type of the object being requested
-     * @param clazz The class of the object being requested
-     * @return An instance of the requested class
+     * @param <T>   type of the object being requested
+     * @param clazz class of the object being requested
+     * @return an instance of the requested class
      */
     public static <T> T getInstance(final Class<T> clazz) {
         return injector.getInstance(clazz);

--- a/server/src/main/java/com/ao/data/dao/ini/UserDAOIni.java
+++ b/server/src/main/java/com/ao/data/dao/ini/UserDAOIni.java
@@ -173,12 +173,10 @@ public class UserDAOIni implements AccountDAO, UserCharacterDAO {
     public Account retrieve(String username) throws DAOException {
         Ini chara = readCharFile(username);
 
-        if (null == chara) {
-            return null;
-        }
+        if (null == chara) return null;
 
-        // Add the single character's name.
-        Set<String> characters = new HashSet<String>();
+        // Add the single character's name
+        Set<String> characters = new HashSet<>();
         characters.add(username);
 
         return new AccountImpl(
@@ -191,12 +189,10 @@ public class UserDAOIni implements AccountDAO, UserCharacterDAO {
     }
 
     @Override
-    public Account create(String name, String password, String mail)
-            throws DAOException, NameAlreadyTakenException {
+    public Account create(String name, String password, String mail) throws DAOException, NameAlreadyTakenException {
 
-        if (exists(name)) {
-            throw new NameAlreadyTakenException();
-        }
+        // If it is not created, then create it
+        if (exists(name)) throw new NameAlreadyTakenException();
 
         Ini acc = new Ini();
 
@@ -207,30 +203,26 @@ public class UserDAOIni implements AccountDAO, UserCharacterDAO {
         try {
             Writer writer = new BufferedWriter(new FileWriter(getCharFilePath(name)));
             acc.store(writer);
-
-            // Make sure the writer is closed, since Ini4j gives no guarantees.
+            // Make sure the writer is closed, since Ini4j gives no guarantees
             writer.close();
         } catch (IOException e) {
             LOGGER.error("Charfile (account data) creation failed!", e);
             throw new DAOException(e);
         }
 
-        return new AccountImpl(name, password, mail, new HashSet<String>(), false);
+        return new AccountImpl(name, password, mail, new HashSet<>(), false);
     }
 
     @Override
     public void delete(String name) {
         File charfile = new File(getCharFilePath(name));
 
-        if (!charfile.exists()) {
-            return;
-        }
+        if (!charfile.exists()) return;
 
         boolean success = charfile.delete();
 
-        if (!success) {
-            LOGGER.error(String.format("Character (%s) deletion failed", name));
-        }
+        if (!success) LOGGER.error(String.format("Character (%s) deletion failed", name));
+
     }
 
     @Override
@@ -292,9 +284,8 @@ public class UserDAOIni implements AccountDAO, UserCharacterDAO {
         chara.put(ATTRIBUTES_HEADER, String.format(ATTRIBUTE_FORMAT_KEY, Attribute.CONSTITUTION.ordinal() + 1), constitution);
         chara.put(ATTRIBUTES_HEADER, String.format(ATTRIBUTE_FORMAT_KEY, Attribute.INTELLIGENCE.ordinal() + 1), intelligence);
 
-        for (byte i = 1; i < Skill.AMOUNT; i++) {
+        for (byte i = 1; i < Skill.AMOUNT; i++)
             chara.put(SKILLS_HEADER, String.format(SKILL_KEY_FORMAT, i + 1), 0);
-        }
 
         chara.put(STATS_HEADER, FREE_SKILL_POINTS_KEY, initialAvailableSkills);
 
@@ -325,9 +316,8 @@ public class UserDAOIni implements AccountDAO, UserCharacterDAO {
         chara.put(REPUTATION_HEADER, NOBLE_POINTS_KEY, INITIAL_NOBLE_POINTS);
         // TODO Assign initial spells.
 
-        for (byte i = 1; i < MAX_PETS_AMOUNT + 1; i++) {
+        for (byte i = 1; i < MAX_PETS_AMOUNT + 1; i++)
             chara.put(PETS_HEADER, String.format(PET_KEY_FORMAT, i), 0);
-        }
 
         chara.put(RESEARCH_HEADER, TRAINING_TIME_KEY, 0);
 
@@ -364,9 +354,7 @@ public class UserDAOIni implements AccountDAO, UserCharacterDAO {
     public UserCharacter load(final ConnectedUser user, final String username) throws DAOException {
         Ini chara = readCharFile(username);
 
-        if (null == chara) {
-            return null;
-        }
+        if (null == chara) return null;
 
         int assassinPoints = Integer.parseInt(chara.get(REPUTATION_HEADER, ASSASSIN_POINTS_KEY));
         int banditPoints = Integer.parseInt(chara.get(REPUTATION_HEADER, BANDIT_POINTS_KEY));
@@ -375,8 +363,7 @@ public class UserDAOIni implements AccountDAO, UserCharacterDAO {
         int noblePoints = Integer.parseInt(chara.get(REPUTATION_HEADER, NOBLE_POINTS_KEY));
         boolean belongsToFaction = "1".equals(chara.get(REPUTATION_HEADER, BELONGS_TO_CHAOS_KEY)) || "1".equals(chara.get(REPUTATION_HEADER, BELONGS_TO_ARMY_KEY));
 
-        Reputation reputation = new ReputationImpl(assassinPoints, banditPoints, bourgeoisPoints, thiefPoints, noblePoints,
-                belongsToFaction);
+        Reputation reputation = new ReputationImpl(assassinPoints, banditPoints, bourgeoisPoints, thiefPoints, noblePoints, belongsToFaction);
 
         Race race = Race.get(Byte.parseByte(chara.get(INIT_HEADER, RACE_KEY)));
 
@@ -390,11 +377,8 @@ public class UserDAOIni implements AccountDAO, UserCharacterDAO {
 
         // TODO check what to do, immobilized state isn't saved in charfile
         boolean immobilized = false;
-
         boolean invisible = false;
-
         boolean mimetized = false;
-
         boolean dumbed = false;
 
         boolean hidden = chara.get(FLAGS_HEADER, HIDDEN_KEY).equals("1");

--- a/server/src/main/java/com/ao/model/character/archetype/UserArchetype.java
+++ b/server/src/main/java/com/ao/model/character/archetype/UserArchetype.java
@@ -7,32 +7,36 @@ import com.ao.ioc.ArchetypeLocator;
  */
 
 public enum UserArchetype {
-    MAGE(MageArchetype.class),
-    CLERIC(ClericArchetype.class),
-    WARRIOR(WarriorArchetype.class),
-    ASSASIN(AssasinArchetype.class),
-    THIEF(ThiefArchetype.class),
-    BARD(BardArchetype.class),
-    DRUID(DruidArchetype.class),
-    BANDIT(BanditArchetype.class),
-    PALADIN(PaladinArchetype.class),
-    HUNTER(HunterArchetype.class),
-    PIRATE(PirateArchetype.class),
-    WORKER(WorkerArchetype.class);
-    // These ones are not used in 0.13.x and later, but left in in case someone want's them ^_^
+    ASSASIN(ArchetypeLocator.getArchetype(AssasinArchetype.class)),
+    BANDIT(ArchetypeLocator.getArchetype(BanditArchetype.class)),
+    BARD(ArchetypeLocator.getArchetype(BardArchetype.class)),
+    CLERIC(ArchetypeLocator.getArchetype(ClericArchetype.class)),
+    DRUID(ArchetypeLocator.getArchetype(DruidArchetype.class)),
+    HUNTER(ArchetypeLocator.getArchetype(HunterArchetype.class)),
+    MAGE(ArchetypeLocator.getArchetype(MageArchetype.class)),
+    PALADIN(ArchetypeLocator.getArchetype(PaladinArchetype.class)),
+    PIRATE(ArchetypeLocator.getArchetype(PirateArchetype.class)),
+    THIEF(ArchetypeLocator.getArchetype(ThiefArchetype.class)),
+    WARRIOR(ArchetypeLocator.getArchetype(WarriorArchetype.class)),
+    WORKER(ArchetypeLocator.getArchetype(WorkerArchetype.class));
+    // These are not used in 0.13.x and later, but left in case someone wants them ^_^
 //	FISHER(ArchetypeLocator.getArchetype(FisherArchetype.class)),
 //	BLACKSMITH(ArchetypeLocator.getArchetype(BlacksmithArchetype.class)),
 //	LUMBERJACK(ArchetypeLocator.getArchetype(LumberjackArchetype.class)),
 //	MINER(ArchetypeLocator.getArchetype(MinerArchetype.class)),
 //	CARPENTER(ArchetypeLocator.getArchetype(CarpenterArchetype.class)),
 
-
     private static final UserArchetype[] values = UserArchetype.values();
-    private final Class<? extends Archetype> archetypeClass;
-    private Archetype archetype; // Lazy init
 
-    UserArchetype(Class<? extends Archetype> archetypeClass) {
-        this.archetypeClass = archetypeClass;
+    private final Archetype archetype;
+
+    /**
+     * Create a new UserArchetype
+     *
+     * @param archetype The Archetype class corresponding to this UserArchetype.
+     */
+    UserArchetype(Archetype archetype) {
+        this.archetype = archetype;
     }
 
     /**
@@ -49,23 +53,21 @@ public enum UserArchetype {
      * Allows retrieving the enum back from the Archetype.
      *
      * @param archetype archetype to look up in the enum
-     * @return The UserArchetype matching the given Archetype, null if none matches
+     * @return the UserArchetype matching the given Archetype, null if none matches
      */
     public static UserArchetype valueOf(Archetype archetype) {
         String archetypeClassName = archetype.getClass().getSimpleName();
         for (UserArchetype arch : values)
-            if (arch.getArchetype().getClass().getSimpleName().equals(archetypeClassName))
-                return arch;
+            if (arch.getArchetype().getClass().getSimpleName().equals(archetypeClassName)) return arch;
         return null;
     }
 
     /**
-     * He gets the associated archetype, initializing it only when used.
+     * Retrieves the Archetype related to this UserArchetype.
      *
-     * @return The Archetype related to this UserArchetype
+     * @return the Archetype related to this UserArchetype
      */
     public Archetype getArchetype() {
-        if (archetype == null) archetype = ArchetypeLocator.getArchetype(archetypeClass);
         return archetype;
     }
 

--- a/server/src/main/resources/project.properties
+++ b/server/src/main/resources/project.properties
@@ -1,3 +1,4 @@
+# Archivos de configuracion desde classpath
 config.path.server=Server.ini
 config.path.archetype=Dat/Balance.dat
 config.path.charfiles=charfiles/
@@ -6,9 +7,13 @@ config.path.objsdat=Dat/obj.dat
 config.path.npcsdat=Dat/NPCs.dat
 config.maps.amount=290
 config.path.citiesdat=Dat/Ciudades.dat
+# Configuracion de seguridad
 config.security.manager=com.ao.security.impl.DefaultSecurityManager
+# Configuracion del servicio de login
 config.loginservice.initialavailableskills=10
+# Configuracion de inventario
 config.inventory.itemperrow=5
+# Configuracion de heads para razas
 config.heads.darkelf.male=201-221
 config.heads.darkelf.female=270-288
 config.heads.dwarf.male=301-319
@@ -19,6 +24,7 @@ config.heads.gnome.male=401-416
 config.heads.gnome.female=470-484
 config.heads.human.male=1-40
 config.heads.human.female=70-89
+# Configuracion de bodies para razas
 config.bodies.darkelf.male=3
 config.bodies.darkelf.female=3
 config.bodies.dwarf.male=300

--- a/server/src/main/resources/project.properties
+++ b/server/src/main/resources/project.properties
@@ -1,7 +1,7 @@
 # Archivos de configuracion desde classpath
 config.path.server=Server.ini
 config.path.archetype=Dat/Balance.dat
-config.path.charfiles=charfiles/
+config.path.charfiles=data/charfiles/
 config.path.maps=Maps/
 config.path.objsdat=Dat/obj.dat
 config.path.npcsdat=Dat/NPCs.dat

--- a/server/src/test/java/com/ao/data/dao/ini/CityDAOIniTest.java
+++ b/server/src/test/java/com/ao/data/dao/ini/CityDAOIniTest.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.fail;
 
 public class CityDAOIniTest {
 
-    private static final String CITIES_DAT_PATH = "src/test/resources/Ciudades.dat";
+    private static final String CITIES_DAT_PATH = "Ciudades.dat";
     private static final String INIT_HEADER = "INIT";
     private static final String NUM_CITIES_KEY = "NumCities";
     private CityDAOIni dao;

--- a/server/src/test/java/com/ao/data/dao/ini/CityDAOIniTest.java
+++ b/server/src/test/java/com/ao/data/dao/ini/CityDAOIniTest.java
@@ -6,8 +6,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.Reader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -32,13 +32,13 @@ public class CityDAOIniTest {
 
         Ini iniFile = null;
 
-        try {
-            // Make sure the reader is closed, since Ini4J gives no guarantees
-            final Reader reader = new BufferedReader(new FileReader(CITIES_DAT_PATH));
+        InputStream inputStream = getClass().getClassLoader().getResourceAsStream(CITIES_DAT_PATH);
+        if (inputStream == null)
+            throw new IllegalArgumentException("The file " + CITIES_DAT_PATH + " was not found in the classpath");
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
             iniFile = new Ini(reader);
-            reader.close();
-        } catch (final Exception e) {
-            fail("Loading of cities failed with message " + e.getMessage());
+        } catch (Exception e) {
+            fail("Cities loading failed! " + e.getMessage());
         }
 
         final int totalCities = Integer.parseInt(iniFile.get(INIT_HEADER, NUM_CITIES_KEY));

--- a/server/src/test/java/com/ao/data/dao/ini/CityDAOIniTest.java
+++ b/server/src/test/java/com/ao/data/dao/ini/CityDAOIniTest.java
@@ -2,15 +2,15 @@ package com.ao.data.dao.ini;
 
 import com.ao.model.map.City;
 import org.ini4j.Ini;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class CityDAOIniTest {
 
@@ -19,7 +19,7 @@ public class CityDAOIniTest {
     private static final String NUM_CITIES_KEY = "NumCities";
     private CityDAOIni dao;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         dao = new CityDAOIni(CITIES_DAT_PATH);
     }
@@ -45,7 +45,7 @@ public class CityDAOIniTest {
 
         final City[] cities = dao.retrieveAll();
 
-        assertEquals(totalCities, cities.length);
+        assertThat(cities.length).isEqualTo(totalCities);
 
     }
 

--- a/server/src/test/java/com/ao/data/dao/ini/NPCPropertiesDAOIniTest.java
+++ b/server/src/test/java/com/ao/data/dao/ini/NPCPropertiesDAOIniTest.java
@@ -35,7 +35,7 @@ public class NPCPropertiesDAOIniTest {
     private static final int BANKER_NPC_INDEX = 23;
     private static final int NOBLE_NPC_INDEX = 71;
 
-    private static final String TEST_NPCS_DAT = "src/test/resources/NPCs.dat";
+    private static final String TEST_NPCS_DAT = "NPCs.dat";
 
     private NPCPropertiesDAOIni dao;
 

--- a/server/src/test/java/com/ao/data/dao/ini/NPCPropertiesDAOIniTest.java
+++ b/server/src/test/java/com/ao/data/dao/ini/NPCPropertiesDAOIniTest.java
@@ -7,11 +7,11 @@ import com.ao.model.character.npc.properties.*;
 import com.ao.model.worldobject.AbstractItem;
 import com.ao.model.worldobject.factory.WorldObjectFactory;
 import com.ao.model.worldobject.properties.WorldObjectProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -39,7 +39,7 @@ public class NPCPropertiesDAOIniTest {
 
     private NPCPropertiesDAOIni dao;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final WorldObjectProperties woProperties = mock(WorldObjectProperties.class);
         final AbstractItem item = mock(AbstractItem.class);
@@ -64,48 +64,49 @@ public class NPCPropertiesDAOIniTest {
         }
 
         final NPCProperties snake = npcProperties[COMMON_NPC_INDEX];
-        assertThat(snake, instanceOf(CreatureNPCProperties.class));
-        assertEquals(NPCType.COMMON, snake.getType());
+        assertThat(snake).isInstanceOf(CreatureNPCProperties.class);
+        assertThat(snake.getType()).isEqualTo(NPCType.COMMON);
 
         final NPCProperties dragon = npcProperties[DRAGON_NPC_INDEX];
-        assertThat(dragon, instanceOf(CreatureNPCProperties.class));
-        assertEquals(NPCType.DRAGON, dragon.getType());
+        assertThat(dragon).isInstanceOf(CreatureNPCProperties.class);
+        assertThat(dragon.getType()).isEqualTo(NPCType.DRAGON);
 
         final NPCProperties trainer = npcProperties[TRAINER_NPC_INDEX];
-        assertThat(trainer, instanceOf(TrainerNPCProperties.class));
-        assertEquals(NPCType.TRAINER, trainer.getType());
+        assertThat(trainer).isInstanceOf(TrainerNPCProperties.class);
+        assertThat(trainer.getType()).isEqualTo(NPCType.TRAINER);
 
         final NPCProperties governor = npcProperties[GOVERNOR_NPC_INDEX];
-        assertThat(governor, instanceOf(GovernorNPCProperties.class));
-        assertEquals(NPCType.GOVERNOR, governor.getType());
+        assertThat(governor).isInstanceOf(GovernorNPCProperties.class);
+        assertThat(governor.getType()).isEqualTo(NPCType.GOVERNOR);
 
         final NPCProperties royalGuard = npcProperties[ROYAL_GUARD_NPC_INDEX];
-        assertThat(royalGuard, instanceOf(GuardNPCProperties.class));
-        assertEquals(NPCType.ROYAL_GUARD, royalGuard.getType());
+        assertThat(royalGuard).isInstanceOf(GuardNPCProperties.class);
+        assertThat(royalGuard.getType()).isEqualTo(NPCType.ROYAL_GUARD);
 
         final NPCProperties chaosGuard = npcProperties[CHAOS_GUARD_NPC_INDEX];
-        assertThat(chaosGuard, instanceOf(GuardNPCProperties.class));
-        assertEquals(NPCType.CHAOS_GUARD, chaosGuard.getType());
+        assertThat(chaosGuard).isInstanceOf(GuardNPCProperties.class);
+        assertThat(chaosGuard.getType()).isEqualTo(NPCType.CHAOS_GUARD);
 
         final NPCProperties newbieResucitator = npcProperties[NEWBIE_RESUCITATOR_NPC_INDEX];
-        assertThat(newbieResucitator, instanceOf(NPCProperties.class));
-        assertEquals(NPCType.NEWBIE_RESUCITATOR, newbieResucitator.getType());
+        assertThat(newbieResucitator).isInstanceOf(NPCProperties.class);
+        assertThat(newbieResucitator.getType()).isEqualTo(NPCType.NEWBIE_RESUCITATOR);
 
         final NPCProperties resucitator = npcProperties[RESUCITATOR_NPC_INDEX];
-        assertThat(resucitator, instanceOf(NPCProperties.class));
-        assertEquals(NPCType.RESUCITATOR, resucitator.getType());
+        assertThat(resucitator).isInstanceOf(NPCProperties.class);
+        assertThat(resucitator.getType()).isEqualTo(NPCType.RESUCITATOR);
 
         final NPCProperties gambler = npcProperties[GAMBLER_NPC_INDEX];
-        assertThat(gambler, instanceOf(NPCProperties.class));
-        assertEquals(NPCType.GAMBLER, gambler.getType());
+        assertThat(gambler).isInstanceOf(NPCProperties.class);
+        assertThat(gambler.getType()).isEqualTo(NPCType.GAMBLER);
 
         final NPCProperties banker = npcProperties[BANKER_NPC_INDEX];
-        assertThat(banker, instanceOf(NPCProperties.class));
-        assertEquals(NPCType.BANKER, banker.getType());
+        assertThat(banker).isInstanceOf(NPCProperties.class);
+        assertThat(banker.getType()).isEqualTo(NPCType.BANKER);
 
         final NPCProperties noble = npcProperties[NOBLE_NPC_INDEX];
-        assertThat(noble, instanceOf(NobleNPCProperties.class));
-        assertEquals(NPCType.NOBLE, noble.getType());
+        assertThat(noble).isInstanceOf(NobleNPCProperties.class);
+        assertThat(noble.getType()).isEqualTo(NPCType.NOBLE);
+
     }
 
 }

--- a/server/src/test/java/com/ao/data/dao/ini/UserDAOIniTest.java
+++ b/server/src/test/java/com/ao/data/dao/ini/UserDAOIniTest.java
@@ -1,5 +1,6 @@
 package com.ao.data.dao.ini;
 
+import com.ao.context.ApplicationProperties;
 import com.ao.data.dao.exception.DAOException;
 import com.ao.model.character.Gender;
 import com.ao.model.character.Race;
@@ -14,6 +15,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -31,7 +34,8 @@ public class UserDAOIniTest {
     public void setUp() throws Exception {
         // Disable escaping for Ini4j
         System.setProperty("org.ini4j.config.escape", "false");
-        dao = new UserDAOIni(CHARFILES_PATH);
+        String charfilesPath = ApplicationProperties.getProperties().getProperty("config.path.charfiles");
+        dao = new UserDAOIni(charfilesPath);
     }
 
     @AfterEach
@@ -80,6 +84,7 @@ public class UserDAOIniTest {
 
     @Test
     public void testCreateCharacter() throws DAOException {
+
         final byte[] skills = new byte[Skill.AMOUNT];
 
         for (int i = 0; i < Skill.AMOUNT; i++) {

--- a/server/src/test/java/com/ao/data/dao/ini/UserDAOIniTest.java
+++ b/server/src/test/java/com/ao/data/dao/ini/UserDAOIniTest.java
@@ -24,7 +24,7 @@ public class UserDAOIniTest {
     private static final String NEW_CHARACTER_NICK = "newchartest";
     private static final String CHARACTER_MAIL = "test@test.com";
     private static final String CHARACTER_PASSWORD = "testpass";
-    private static final String CHARFILES_PATH = "src/test/resources/charfiles/";
+    private static final String CHARFILES_PATH = "charfiles/";
     private UserDAOIni dao;
 
     @Before

--- a/server/src/test/java/com/ao/data/dao/ini/UserDAOIniTest.java
+++ b/server/src/test/java/com/ao/data/dao/ini/UserDAOIniTest.java
@@ -9,13 +9,13 @@ import com.ao.model.character.archetype.UserArchetype;
 import com.ao.model.map.City;
 import com.ao.model.user.Account;
 import com.ao.model.user.ConnectedUser;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class UserDAOIniTest {
@@ -27,14 +27,14 @@ public class UserDAOIniTest {
     private static final String CHARFILES_PATH = "charfiles/";
     private UserDAOIni dao;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         // Disable escaping for Ini4j
         System.setProperty("org.ini4j.config.escape", "false");
         dao = new UserDAOIni(CHARFILES_PATH);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         // Be really sure the file is not there before the next test
         final File file = new File(dao.getCharFilePath(NEW_CHARACTER_NICK));
@@ -44,23 +44,23 @@ public class UserDAOIniTest {
     @Test
     public void testRetrieve() throws DAOException {
         final Account acc = dao.retrieve(CHARACTER_NICK);
-        assertNotNull(acc);
+        assertThat(acc).isNotNull();
         // Ensure we get the requested character and not another one
-        assertEquals(CHARACTER_NICK, acc.getName());
+        assertThat(acc.getName()).isEqualTo(CHARACTER_NICK);
     }
 
     @Test
     public void testCreateAccount() throws DAOException {
         final Account acc = dao.create(NEW_CHARACTER_NICK, CHARACTER_PASSWORD, CHARACTER_MAIL);
 
-        assertEquals(NEW_CHARACTER_NICK, acc.getName());
-        assertEquals(CHARACTER_MAIL, acc.getMail());
+        assertThat(acc.getName()).isEqualTo(NEW_CHARACTER_NICK);
+        assertThat(acc.getMail()).isEqualTo(CHARACTER_MAIL);
 
-        assertTrue(acc.authenticate(CHARACTER_PASSWORD));
+        assertThat(acc.authenticate(CHARACTER_PASSWORD)).isTrue();
 
         final File file = new File(dao.getCharFilePath(NEW_CHARACTER_NICK));
 
-        assertTrue(file.exists());
+        assertThat(file.exists()).isTrue();
 
         // Don't leave the file there!
         file.delete();
@@ -71,11 +71,11 @@ public class UserDAOIniTest {
         dao.create(NEW_CHARACTER_NICK, CHARACTER_PASSWORD, CHARACTER_MAIL);
         final File file = new File(dao.getCharFilePath(NEW_CHARACTER_NICK));
 
-        assertTrue(file.exists());
+        assertThat(file.exists()).isTrue();
 
         dao.delete(NEW_CHARACTER_NICK);
 
-        assertFalse(file.exists());
+        assertThat(file.exists()).isFalse();
     }
 
     @Test
@@ -96,13 +96,13 @@ public class UserDAOIniTest {
 
         final File file = new File(dao.getCharFilePath(NEW_CHARACTER_NICK));
 
-        assertTrue(file.exists());
+        assertThat(file.exists()).isTrue();
 
-        assertEquals(NEW_CHARACTER_NICK, chara.getName());
-        assertEquals(UserArchetype.ASSASIN.getArchetype(), chara.getArchetype());
-        assertEquals(Gender.FEMALE, chara.getGender());
-        assertEquals(Race.HUMAN, chara.getRace());
-        assertEquals((byte) 1, chara.getLevel());
+        assertThat(chara.getName()).isEqualTo(NEW_CHARACTER_NICK);
+        assertThat(chara.getArchetype()).isEqualTo(UserArchetype.ASSASIN.getArchetype());
+        assertThat(chara.getGender()).isEqualTo(Gender.FEMALE);
+        assertThat(chara.getRace()).isEqualTo(Race.HUMAN);
+        assertThat(chara.getLevel()).isEqualTo((byte) 1);
 
         // TODO To be continued... :P
 

--- a/server/src/test/java/com/ao/data/dao/ini/UserDAOIniTest.java
+++ b/server/src/test/java/com/ao/data/dao/ini/UserDAOIniTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -27,7 +25,6 @@ public class UserDAOIniTest {
     private static final String NEW_CHARACTER_NICK = "newchartest";
     private static final String CHARACTER_MAIL = "test@test.com";
     private static final String CHARACTER_PASSWORD = "testpass";
-    private static final String CHARFILES_PATH = "charfiles/";
     private UserDAOIni dao;
 
     @BeforeEach

--- a/server/src/test/java/com/ao/data/dao/ini/WorldObjectPropertiesDAOIniTest.java
+++ b/server/src/test/java/com/ao/data/dao/ini/WorldObjectPropertiesDAOIniTest.java
@@ -24,7 +24,7 @@ public class WorldObjectPropertiesDAOIniTest {
     private static final int MINERAL_INDEX = 192;
 
 
-    private static final String TEST_OBJ_DAT = "src/test/resources/obj.dat";
+    private static final String TEST_OBJ_DAT = "obj.dat";
     private static final int TEST_ITEMS_PER_ROW = 5;
 
     protected WorldObjectPropertiesDAOIni dao;

--- a/server/src/test/java/com/ao/data/dao/ini/WorldObjectPropertiesDAOIniTest.java
+++ b/server/src/test/java/com/ao/data/dao/ini/WorldObjectPropertiesDAOIniTest.java
@@ -3,11 +3,11 @@ package com.ao.data.dao.ini;
 import com.ao.data.dao.exception.DAOException;
 import com.ao.model.worldobject.WorldObjectType;
 import com.ao.model.worldobject.properties.*;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class WorldObjectPropertiesDAOIniTest {
 
@@ -29,7 +29,7 @@ public class WorldObjectPropertiesDAOIniTest {
 
     protected WorldObjectPropertiesDAOIni dao;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         dao = new WorldObjectPropertiesDAOIni(TEST_OBJ_DAT, TEST_ITEMS_PER_ROW);
     }
@@ -44,44 +44,44 @@ public class WorldObjectPropertiesDAOIniTest {
 
         // Check some items to make sure they loaded properly...
         final WorldObjectProperties yellowPotion = dao.getWorldObjectProperties(YELLOW_POTION_INDEX);
-        assertThat(yellowPotion, instanceOf(TemporalStatModifyingItemProperties.class));
-        assertEquals(WorldObjectType.DEXTERITY_POTION, yellowPotion.getType());
+        assertThat(yellowPotion).isInstanceOf(TemporalStatModifyingItemProperties.class);
+        assertThat(yellowPotion.getType()).isEqualTo(WorldObjectType.DEXTERITY_POTION);
 
         final WorldObjectProperties bluePotion = dao.getWorldObjectProperties(BLUE_POTION_INDEX);
-        assertThat(bluePotion, instanceOf(StatModifyingItemProperties.class));
-        assertEquals(WorldObjectType.MANA_POTION, bluePotion.getType());
+        assertThat(bluePotion).isInstanceOf(StatModifyingItemProperties.class);
+        assertThat(bluePotion.getType()).isEqualTo(WorldObjectType.MANA_POTION);
 
         final WorldObjectProperties redPotion = dao.getWorldObjectProperties(RED_POTION_INDEX);
-        assertThat(redPotion, instanceOf(StatModifyingItemProperties.class));
-        assertEquals(WorldObjectType.HP_POTION, redPotion.getType());
+        assertThat(redPotion).isInstanceOf(StatModifyingItemProperties.class);
+        assertThat(redPotion.getType()).isEqualTo(WorldObjectType.HP_POTION);
 
         final WorldObjectProperties greenPotion = dao.getWorldObjectProperties(GREEN_POTION_INDEX);
-        assertThat(greenPotion, instanceOf(TemporalStatModifyingItemProperties.class));
-        assertEquals(WorldObjectType.STRENGTH_POTION, greenPotion.getType());
+        assertThat(greenPotion).isInstanceOf(TemporalStatModifyingItemProperties.class);
+        assertThat(greenPotion.getType()).isEqualTo(WorldObjectType.STRENGTH_POTION);
 
         final WorldObjectProperties violetPotion = dao.getWorldObjectProperties(VIOLET_POTION_INDEX);
-        assertThat(violetPotion, instanceOf(ItemProperties.class));
-        assertEquals(WorldObjectType.POISON_POTION, violetPotion.getType());
+        assertThat(violetPotion).isInstanceOf(ItemProperties.class);
+        assertThat(violetPotion.getType()).isEqualTo(WorldObjectType.POISON_POTION);
 
         final WorldObjectProperties blackPotion = dao.getWorldObjectProperties(BLACK_POTION_INDEX);
-        assertThat(blackPotion, instanceOf(ItemProperties.class));
-        assertEquals(WorldObjectType.DEATH_POTION, blackPotion.getType());
+        assertThat(blackPotion).isInstanceOf(ItemProperties.class);
+        assertThat(blackPotion.getType()).isEqualTo(WorldObjectType.DEATH_POTION);
 
         final WorldObjectProperties sign = dao.getWorldObjectProperties(SIGN_INDEX);
-        assertThat(sign, instanceOf(SignProperties.class));
-        assertEquals(WorldObjectType.SIGN, sign.getType());
+        assertThat(sign).isInstanceOf(SignProperties.class);
+        assertThat(sign.getType()).isEqualTo(WorldObjectType.SIGN);
 
         final WorldObjectProperties ullathorpeForum = dao.getWorldObjectProperties(ULLATHORPE_FORUM_INDEX);
-        assertThat(ullathorpeForum, instanceOf(ForumProperties.class));
-        assertEquals(WorldObjectType.FORUM, ullathorpeForum.getType());
+        assertThat(ullathorpeForum).isInstanceOf(ForumProperties.class);
+        assertThat(ullathorpeForum.getType()).isEqualTo(WorldObjectType.FORUM);
 
         final WorldObjectProperties backpack = dao.getWorldObjectProperties(BACKPACK_INDEX);
-        assertThat(backpack, instanceOf(BackpackProperties.class));
-        assertEquals(WorldObjectType.BACKPACK, backpack.getType());
+        assertThat(backpack).isInstanceOf(BackpackProperties.class);
+        assertThat(backpack.getType()).isEqualTo(WorldObjectType.BACKPACK);
 
         final WorldObjectProperties mineral = dao.getWorldObjectProperties(MINERAL_INDEX);
-        assertThat(mineral, instanceOf(MineralProperties.class));
-        assertEquals(WorldObjectType.MINERAL, mineral.getType());
+        assertThat(mineral).isInstanceOf(MineralProperties.class);
+        assertThat(mineral.getType()).isEqualTo(WorldObjectType.MINERAL);
 
         // TODO Keep doing this with other object types. Also check some other attributes are properly loaded...
     }

--- a/server/src/test/java/com/ao/data/dao/map/WorldMapDAOImplTest.java
+++ b/server/src/test/java/com/ao/data/dao/map/WorldMapDAOImplTest.java
@@ -11,8 +11,8 @@ import static org.junit.Assert.*;
 
 public class WorldMapDAOImplTest {
 
-    private static final String MAPS_PATH = "src/test/resources/maps/";
-    private static final String MAPS_CONFIG_FILE = "resources/maps.properties";
+    private static final String MAPS_PATH = "maps/";
+    private static final String MAPS_CONFIG_FILE = "maps.properties";
     private WorldMapDAO dao;
 
     @Before

--- a/server/src/test/java/com/ao/data/dao/map/WorldMapDAOImplTest.java
+++ b/server/src/test/java/com/ao/data/dao/map/WorldMapDAOImplTest.java
@@ -4,10 +4,10 @@ import com.ao.data.dao.WorldMapDAO;
 import com.ao.model.map.Position;
 import com.ao.model.map.Trigger;
 import com.ao.model.map.WorldMap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class WorldMapDAOImplTest {
 
@@ -15,7 +15,7 @@ public class WorldMapDAOImplTest {
     private static final String MAPS_CONFIG_FILE = "maps.properties";
     private WorldMapDAO dao;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         dao = new WorldMapDAOImpl(MAPS_PATH, 1, MAPS_CONFIG_FILE);
     }
@@ -26,31 +26,31 @@ public class WorldMapDAOImplTest {
         final WorldMap map = maps[0];
 
         // Check for blocked/non-blocked
-        assertTrue(map.getTile(0, 0).isBlocked());
-        assertFalse(map.getTile(83, 28).isBlocked());
+        assertThat(map.getTile(0, 0).isBlocked()).isTrue();
+        assertThat(map.getTile(83, 28).isBlocked()).isFalse();
 
         // Check if tile exits are where expected
-        assertNull(map.getTile(49, 49).getTileExit());
+        assertThat(map.getTile(49, 49).getTileExit()).isNull();
 
         final Position tileExit = map.getTile(19, 84).getTileExit();
-        assertTrue(tileExit != null);
-        assertTrue(tileExit.getX() >= WorldMap.MIN_X);
-        assertTrue(tileExit.getX() <= WorldMap.MAX_X);
-        assertTrue(tileExit.getY() >= WorldMap.MIN_Y);
-        assertTrue(tileExit.getY() <= WorldMap.MAX_Y);
+        assertThat(tileExit != null).isTrue();
+        assertThat(tileExit.getX()).isGreaterThanOrEqualTo((byte) WorldMap.MIN_X);
+        assertThat(tileExit.getX()).isLessThanOrEqualTo((byte) WorldMap.MAX_X);
+        assertThat(tileExit.getX()).isGreaterThanOrEqualTo((byte) WorldMap.MIN_Y);
+        assertThat(tileExit.getX()).isLessThanOrEqualTo((byte) WorldMap.MAX_Y);
 
-        assertEquals(map.getTile(0, 0).getTrigger(), Trigger.NONE);
-        assertEquals(map.getTile(23, 32).getTrigger(), Trigger.UNDER_ROOF);
-        assertEquals(map.getTile(57, 44).getTrigger(), Trigger.INVALID_POSITION);
-        assertEquals(map.getTile(40, 74).getTrigger(), Trigger.SAFE_ZONE);
-        assertEquals(map.getTile(28, 20).getTrigger(), Trigger.ANTI_PICKET);
-        assertEquals(map.getTile(23, 33).getTrigger(), Trigger.FIGHT_ZONE);
+        assertThat(Trigger.NONE).isEqualTo(map.getTile(0, 0).getTrigger());
+        assertThat(Trigger.UNDER_ROOF).isEqualTo(map.getTile(23, 32).getTrigger());
+        assertThat(Trigger.INVALID_POSITION).isEqualTo(map.getTile(57, 44).getTrigger());
+        assertThat(Trigger.SAFE_ZONE).isEqualTo(map.getTile(40, 74).getTrigger());
+        assertThat(Trigger.ANTI_PICKET).isEqualTo(map.getTile(28, 20).getTrigger());
+        assertThat(Trigger.FIGHT_ZONE).isEqualTo(map.getTile(23, 33).getTrigger());
 
-        assertTrue(map.getTile(71, 55).isLava());
-        assertFalse(map.getTile(71, 55).isWater());
+        assertThat(map.getTile(71, 55).isLava()).isTrue();
+        assertThat(map.getTile(71, 55).isWater()).isFalse();
 
-        assertFalse(map.getTile(76, 72).isLava());
-        assertTrue(map.getTile(76, 72).isWater());
+        assertThat(map.getTile(76, 72).isLava()).isFalse();
+        assertThat(map.getTile(76, 72).isWater()).isTrue();
     }
 
 }

--- a/server/src/test/java/com/ao/mock/MockFactory.java
+++ b/server/src/test/java/com/ao/mock/MockFactory.java
@@ -26,12 +26,7 @@ public class MockFactory {
         when(item.getId()).thenReturn(id);
         when(item.getAmount()).thenCallRealMethod();
         when(item.addAmount(anyInt())).thenCallRealMethod();
-        when(item.clone()).thenAnswer(new Answer<Item>() {
-            @Override
-            public Item answer(final InvocationOnMock invocation) throws Throwable {
-                return mockItem(item.getId(), item.getAmount());
-            }
-        });
+        when(item.clone()).thenAnswer((Answer<Item>) invocation -> mockItem(item.getId(), item.getAmount()));
 
         // initialize amount
         item.addAmount(initialAmount);
@@ -116,8 +111,9 @@ public class MockFactory {
 
     /**
      * Creates a new TimedEvent mock with a default mocked Character.
-     *
+     * <p>
      * // @param executions The amount of the executions the event would have
+     *
      * @return the created mock
      */
     public static TimedEvent mockTimedEvent() {

--- a/server/src/test/java/com/ao/model/character/ReputationImplTest.java
+++ b/server/src/test/java/com/ao/model/character/ReputationImplTest.java
@@ -1,9 +1,9 @@
 package com.ao.model.character;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReputationImplTest {
 
@@ -16,7 +16,7 @@ public class ReputationImplTest {
 
     private Reputation rep;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         rep = new ReputationImpl(ASSASIN_POINTS, BANDIT_POINTS, BURGEOIS_POINTS, THIEFF_POINTS, NOBLE_POINTS, BELONGS_TO_FACTION);
     }
@@ -24,74 +24,74 @@ public class ReputationImplTest {
     @Test
     public void testAddToAssassin() {
         rep.addToAssassin(10);
-        assertEquals(ASSASIN_POINTS + 10, rep.getAssassin());
+        assertThat(rep.getAssassin()).isEqualTo(ASSASIN_POINTS + 10);
     }
 
     @Test
     public void testAddToBandit() {
         rep.addToBandit(10);
-        assertEquals(BANDIT_POINTS + 10, rep.getBandit());
+        assertThat(rep.getBandit()).isEqualTo(BANDIT_POINTS + 10);
     }
 
     @Test
     public void testAddToBourgeois() {
         rep.addToBourgeois(10);
-        assertEquals(BURGEOIS_POINTS + 10, rep.getBourgeois());
+        assertThat(rep.getBourgeois()).isEqualTo(BURGEOIS_POINTS + 10);
     }
 
     @Test
     public void testAddToNoblePoints() {
         rep.addToNoble(10);
-        assertEquals(NOBLE_POINTS + 10, rep.getNoble());
+        assertThat(rep.getNoble()).isEqualTo(NOBLE_POINTS + 10);
     }
 
     @Test
     public void testAddToThief() {
         rep.addToThief(10);
-        assertEquals(THIEFF_POINTS + 10, rep.getThief());
+        assertThat(rep.getThief()).isEqualTo(THIEFF_POINTS + 10);
     }
 
     @Test
     public void testGetAlignment() {
-        assertSame(Alignment.CRIMINAL, rep.getAlignment());
+        assertThat(rep.getAlignment()).isSameAs(Alignment.CRIMINAL);
         rep.addToNoble(600);
-        assertSame(Alignment.CITIZEN, rep.getAlignment());
+        assertThat(rep.getAlignment()).isSameAs(Alignment.CITIZEN);
     }
 
     @Test
     public void testGetAssassin() {
-        assertEquals(ASSASIN_POINTS, rep.getAssassin());
+        assertThat(rep.getAssassin()).isEqualTo(ASSASIN_POINTS);
     }
 
     @Test
     public void testGetBandit() {
-        assertEquals(BANDIT_POINTS, rep.getBandit());
+        assertThat(rep.getBandit()).isEqualTo(BANDIT_POINTS);
     }
 
     @Test
     public void testGetBourgeois() {
-        assertEquals(BURGEOIS_POINTS, rep.getBourgeois());
+        assertThat(rep.getBourgeois()).isEqualTo(BURGEOIS_POINTS);
     }
 
     @Test
     public void testGetThief() {
-        assertEquals(THIEFF_POINTS, rep.getThief());
+        assertThat(rep.getThief()).isEqualTo(THIEFF_POINTS);
     }
 
     @Test
     public void testGetNoble() {
-        assertEquals(NOBLE_POINTS, rep.getNoble());
+        assertThat(rep.getNoble()).isEqualTo(NOBLE_POINTS);
     }
 
     @Test
     public void testBelongsToFaction() {
-        assertFalse(rep.belongsToFaction());
+        assertThat(rep.belongsToFaction()).isFalse();
     }
 
     @Test
     public void testSetBelongsToFaction() {
         rep.setBelongsToFaction(!BELONGS_TO_FACTION);
-        assertEquals(!BELONGS_TO_FACTION, rep.belongsToFaction());
+        assertThat(rep.belongsToFaction()).isEqualTo(!BELONGS_TO_FACTION);
     }
 
 }

--- a/server/src/test/java/com/ao/model/character/archetype/UserArchetypeTest.java
+++ b/server/src/test/java/com/ao/model/character/archetype/UserArchetypeTest.java
@@ -20,14 +20,13 @@ public class UserArchetypeTest {
         assertThat(UserArchetype.PIRATE.getArchetype()).isInstanceOf(PirateArchetype.class);
         assertThat(UserArchetype.THIEF.getArchetype()).isInstanceOf(ThiefArchetype.class);
         assertThat(UserArchetype.WARRIOR.getArchetype()).isInstanceOf(WarriorArchetype.class);
-        assertThat(UserArchetype.WORKER.getArchetype()).isInstanceOf(AssasinArchetype.class);
-        assertThat(UserArchetype.ASSASIN.getArchetype()).isInstanceOf(WorkerArchetype.class);
+        assertThat(UserArchetype.WORKER.getArchetype()).isInstanceOf(WorkerArchetype.class);
     }
 
     @Test
     public void testValueOf() {
-        final Archetype arch = ArchetypeLocator.getArchetype(AssasinArchetype.class);
-        assertThat(UserArchetype.ASSASIN).isSameAs(UserArchetype.valueOf(arch));
+        final Archetype archetype = ArchetypeLocator.getArchetype(AssasinArchetype.class); // Es necesario declararlo como final?
+        assertThat(UserArchetype.ASSASIN).isSameAs(UserArchetype.valueOf(archetype));
     }
 
 }

--- a/server/src/test/java/com/ao/model/character/archetype/UserArchetypeTest.java
+++ b/server/src/test/java/com/ao/model/character/archetype/UserArchetypeTest.java
@@ -1,34 +1,33 @@
 package com.ao.model.character.archetype;
 
 import com.ao.ioc.ArchetypeLocator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class UserArchetypeTest {
 
     @Test
     public void testGetArchetype() {
-        assertThat(UserArchetype.ASSASIN.getArchetype(), instanceOf(AssasinArchetype.class));
-        assertThat(UserArchetype.BANDIT.getArchetype(), instanceOf(BanditArchetype.class));
-        assertThat(UserArchetype.BARD.getArchetype(), instanceOf(BardArchetype.class));
-        assertThat(UserArchetype.CLERIC.getArchetype(), instanceOf(ClericArchetype.class));
-        assertThat(UserArchetype.DRUID.getArchetype(), instanceOf(DruidArchetype.class));
-        assertThat(UserArchetype.HUNTER.getArchetype(), instanceOf(HunterArchetype.class));
-        assertThat(UserArchetype.MAGE.getArchetype(), instanceOf(MageArchetype.class));
-        assertThat(UserArchetype.PALADIN.getArchetype(), instanceOf(PaladinArchetype.class));
-        assertThat(UserArchetype.PIRATE.getArchetype(), instanceOf(PirateArchetype.class));
-        assertThat(UserArchetype.THIEF.getArchetype(), instanceOf(ThiefArchetype.class));
-        assertThat(UserArchetype.WARRIOR.getArchetype(), instanceOf(WarriorArchetype.class));
-        assertThat(UserArchetype.WORKER.getArchetype(), instanceOf(WorkerArchetype.class));
+        assertThat(UserArchetype.ASSASIN.getArchetype()).isInstanceOf(AssasinArchetype.class);
+        assertThat(UserArchetype.BANDIT.getArchetype()).isInstanceOf(BanditArchetype.class);
+        assertThat(UserArchetype.BARD.getArchetype()).isInstanceOf(BardArchetype.class);
+        assertThat(UserArchetype.CLERIC.getArchetype()).isInstanceOf(ClericArchetype.class);
+        assertThat(UserArchetype.DRUID.getArchetype()).isInstanceOf(DruidArchetype.class);
+        assertThat(UserArchetype.HUNTER.getArchetype()).isInstanceOf(HunterArchetype.class);
+        assertThat(UserArchetype.MAGE.getArchetype()).isInstanceOf(MageArchetype.class);
+        assertThat(UserArchetype.PALADIN.getArchetype()).isInstanceOf(PaladinArchetype.class);
+        assertThat(UserArchetype.PIRATE.getArchetype()).isInstanceOf(PirateArchetype.class);
+        assertThat(UserArchetype.THIEF.getArchetype()).isInstanceOf(ThiefArchetype.class);
+        assertThat(UserArchetype.WARRIOR.getArchetype()).isInstanceOf(WarriorArchetype.class);
+        assertThat(UserArchetype.WORKER.getArchetype()).isInstanceOf(AssasinArchetype.class);
+        assertThat(UserArchetype.ASSASIN.getArchetype()).isInstanceOf(WorkerArchetype.class);
     }
 
     @Test
     public void testValueOf() {
         final Archetype arch = ArchetypeLocator.getArchetype(AssasinArchetype.class);
-        assertSame(UserArchetype.valueOf(arch), UserArchetype.ASSASIN);
+        assertThat(UserArchetype.ASSASIN).isSameAs(UserArchetype.valueOf(arch));
     }
 
 }

--- a/server/src/test/java/com/ao/model/character/movement/GreedyMovementStrategyTest.java
+++ b/server/src/test/java/com/ao/model/character/movement/GreedyMovementStrategyTest.java
@@ -3,9 +3,9 @@ package com.ao.model.character.movement;
 import com.ao.model.character.Character;
 import com.ao.model.map.Heading;
 import com.ao.model.map.Position;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -54,7 +54,7 @@ public class GreedyMovementStrategyTest {
     }
 
     private void _moveTest(final Position pos, final Position target, final Heading shouldnt1, final Heading shouldnt2) {
-        // Save these values because they will change and we don't want to modify the original object.
+        // Save these values because they will change, and we don't want to modify the original object.
         final byte x = pos.getX();
         final byte y = pos.getY();
 
@@ -64,15 +64,15 @@ public class GreedyMovementStrategyTest {
             final Heading move = movement.move(pos);
             movePosition(pos, move);
 
-            assertNotNull(move);
-            assertNotSame(shouldnt1, move);
-            assertNotSame(shouldnt2, move);
+            assertThat(move).isNotNull();
+            assertThat(shouldnt1).isNotSameAs(move);
+            assertThat(shouldnt2).isNotSameAs(move);
         }
 
-        // Has arrived to target.
-        assertEquals(target.getX(), pos.getX());
-        assertEquals(target.getY(), pos.getY());
-        assertNull(movement.move(pos));
+        // Has arrived to target
+        assertThat(pos.getX()).isEqualTo(target.getX());
+        assertThat(pos.getY()).isEqualTo(target.getY());
+        assertThat(movement.move(pos)).isNull();
 
         pos.setX(x);
         pos.setY(y);

--- a/server/src/test/java/com/ao/model/character/movement/QuietMovementStrategyTest.java
+++ b/server/src/test/java/com/ao/model/character/movement/QuietMovementStrategyTest.java
@@ -2,9 +2,9 @@ package com.ao.model.character.movement;
 
 import com.ao.model.character.Character;
 import com.ao.model.map.Position;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class QuietMovementStrategyTest {
@@ -18,13 +18,13 @@ public class QuietMovementStrategyTest {
 
         movement.setTarget(target);
 
-        assertNull(movement.move(pos));
+        assertThat(movement.move(pos)).isNull();
 
         final Character character = mock(Character.class);
 
         movement.setTarget(character);
 
-        assertNull(movement.move(pos));
+        assertThat(movement.move(pos)).isNotNull();
     }
 
 }

--- a/server/src/test/java/com/ao/model/character/movement/QuietMovementStrategyTest.java
+++ b/server/src/test/java/com/ao/model/character/movement/QuietMovementStrategyTest.java
@@ -24,7 +24,7 @@ public class QuietMovementStrategyTest {
 
         movement.setTarget(character);
 
-        assertThat(movement.move(pos)).isNotNull();
+        assertThat(movement.move(pos)).isNull();
     }
 
 }

--- a/server/src/test/java/com/ao/model/inventory/InventoryImplTest.java
+++ b/server/src/test/java/com/ao/model/inventory/InventoryImplTest.java
@@ -45,7 +45,7 @@ public class InventoryImplTest {
         assertThat(inventory.addItem(newItem)).isEqualTo(0);
         assertThat(inventory.getItemAmount(newItem)).isEqualTo(3);
 
-        // Try to add an item that is repeated when inventory isn't full and the item amount exceeds the limit.
+        // Try to add an item repeated when inventory isn't full and the item amount exceeds the limit.
         inventory.removeItem(0);
         inventory.addItem(item[0]);
 
@@ -120,8 +120,11 @@ public class InventoryImplTest {
         inventory.removeItem(itemRemoved);
         assertThat(inventory.hasItem(item2)).isNotEqualTo(-1);
 
-        // Try to remove an item not in inventory
-        assertThat(inventory.hasItem(item2)).isNull();
+        // Try to check an item not in inventory
+        assertThat(inventory.hasItem(itemRemoved)).isEqualTo(-1);
+
+        // item2 IS in inventory (added above), it should return to its position
+        assertThat(inventory.hasItem(item2)).isNotEqualTo(-1);
     }
 
     @Test

--- a/server/src/test/java/com/ao/model/inventory/InventoryImplTest.java
+++ b/server/src/test/java/com/ao/model/inventory/InventoryImplTest.java
@@ -2,18 +2,17 @@ package com.ao.model.inventory;
 
 import com.ao.mock.MockFactory;
 import com.ao.model.worldobject.Item;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class InventoryImplTest {
 
     private Inventory inventory;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         inventory = new InventoryImpl();
     }
@@ -25,33 +24,33 @@ public class InventoryImplTest {
         for (int i = 0; i < inventory.getCapacity(); i++) {
             // Basic item mock
             item[i] = MockFactory.mockItem(i + 1, 1);
-            assertEquals(0, inventory.addItem(item[i]));
+            assertThat(inventory.addItem(item[i])).isEqualTo(0);
         }
 
         // TODO Split this test into 3/4
 
-        // Try to add an item when inventory is full and item not repeated.
+        // Try to add an item when inventory is full and item not repeated
         final Item newItem = mock(Item.class);
         when(newItem.getAmount()).thenReturn(1);
-        assertEquals(1, inventory.addItem(newItem));
+        assertThat(inventory.addItem(newItem)).isEqualTo(1);
 
         // Try to add an item that is repeated when inv. Is full
         when(newItem.getId()).thenReturn(2);
-        assertEquals(0, inventory.addItem(newItem));
-        assertEquals(2, inventory.getItemAmount(newItem));
+        assertThat(inventory.addItem(newItem)).isEqualTo(0);
+        assertThat(inventory.getItemAmount(newItem)).isEqualTo(2);
 
-        // Try to add an item repeated when inventory isn't full but item not exceed the limit
+        // Try to add an item repeated when inventory isn't full but item not exceeds the limit
         inventory.removeItem(0);
 
-        assertEquals(0, inventory.addItem(newItem));
-        assertEquals(3, inventory.getItemAmount(newItem));
+        assertThat(inventory.addItem(newItem)).isEqualTo(0);
+        assertThat(inventory.getItemAmount(newItem)).isEqualTo(3);
 
-        // Try to add an item that is repeated when inventory isn't full and item amount exceeds the limit.
+        // Try to add an item that is repeated when inventory isn't full and the item amount exceeds the limit.
         inventory.removeItem(0);
         inventory.addItem(item[0]);
 
         when(newItem.getAmount()).thenReturn(9998);
-        assertThat(inventory.addItem(newItem), greaterThan(0));
+        assertThat(inventory.addItem(newItem)).isGreaterThan(0);
         verify(newItem).addAmount(-9997);
     }
 
@@ -61,7 +60,7 @@ public class InventoryImplTest {
 
         inventory.addItem(item);
         int slot = inventory.hasItem(item);
-        assertNotNull(inventory.getItem(slot));
+        assertThat(inventory.getItem(slot)).isNotNull();
 
         // Test bounds
         inventory.getItem(-1);
@@ -73,20 +72,20 @@ public class InventoryImplTest {
         final Item[] item = new Item[inventory.getCapacity()];
         for (int i = 0; i < inventory.getCapacity(); i++) {
             item[i] = MockFactory.mockItem(i + 1, 1);
-            assertTrue(inventory.hasFreeSlots());
+            assertThat(inventory.hasFreeSlots()).isTrue();
             inventory.addItem(item[i]);
         }
-        assertFalse(inventory.hasFreeSlots());
+        assertThat(inventory.hasFreeSlots()).isFalse();
         inventory.removeItem(0);
-        assertTrue(inventory.hasFreeSlots());
+        assertThat(inventory.hasFreeSlots()).isTrue();
     }
 
     @Test
     public void testHasItem() {
         final Item item = mock(Item.class);
-        assertEquals(-1, inventory.hasItem(item));
+        assertThat(inventory.hasItem(item)).isEqualTo(-1);
         inventory.addItem(item);
-        assertTrue(inventory.hasItem(item) != -1);
+        assertThat(inventory.hasItem(item) != -1).isTrue();
     }
 
     @Test
@@ -94,11 +93,11 @@ public class InventoryImplTest {
         final Item item = mock(Item.class);
         inventory.addItem(item);
         int slot = inventory.hasItem(item);
-        assertNotNull(inventory.removeItem(slot));
-        assertEquals(-1, inventory.hasItem(item));
+        assertThat(inventory.removeItem(slot)).isNotNull();
+        assertThat(inventory.hasItem(item)).isEqualTo(-1);
         // Test bounds
-        assertNull(inventory.removeItem(-1));
-        assertNull(inventory.removeItem(inventory.getCapacity()));
+        assertThat(inventory.removeItem(-1)).isNull();
+        assertThat(inventory.removeItem(inventory.getCapacity())).isNull();
     }
 
     @Test
@@ -114,15 +113,15 @@ public class InventoryImplTest {
         // Completely remove an item from inventory
         inventory.addItem(item);
         inventory.removeItem(item);
-        assertEquals(-1, inventory.hasItem(item));
+        assertThat(inventory.hasItem(item)).isEqualTo(-1);
 
         // Remove an item, by more than can be removed
         inventory.addItem(item2);
         inventory.removeItem(itemRemoved);
-        assertThat(inventory.hasItem(item2), not(equalTo(-1)));
+        assertThat(inventory.hasItem(item2)).isNotEqualTo(-1);
 
         // Try to remove an item not in inventory
-        assertNull(inventory.removeItem(item));
+        assertThat(inventory.hasItem(item2)).isNull();
     }
 
     @Test
@@ -133,16 +132,16 @@ public class InventoryImplTest {
         final int slot = inventory.hasItem(item);
 
         final Item removedItem = inventory.removeItem(slot, 1);
-        assertNotNull(removedItem);
-        assertThat(inventory.hasItem(item), not(equalTo(-1)));
+        assertThat(removedItem).isNotNull();
+        assertThat(inventory.hasItem(item)).isNotEqualTo(-1);
 
         final Item removedItem2 = inventory.removeItem(slot, 1);
-        assertNotNull(removedItem2);
-        assertEquals(-1, inventory.hasItem(item));
+        assertThat(removedItem2).isNotNull();
+        assertThat(inventory.hasItem(item)).isEqualTo(-1);
 
         // Test bounds
-        assertNull(inventory.removeItem(-1, 1));
-        assertNull(inventory.removeItem(inventory.getCapacity(), 1));
+        assertThat(inventory.removeItem(-1, 1)).isNull();
+        assertThat(inventory.removeItem(inventory.getCapacity(), 1)).isNull();
     }
 
     @Test
@@ -151,11 +150,11 @@ public class InventoryImplTest {
         final Item item2 = MockFactory.mockItem(1, 1000);
 
         inventory.addItem(item);
-        assertEquals(1, inventory.getItemAmount(item));
+        assertThat(inventory.getItemAmount(item)).isEqualTo(1);
 
-        // When adding the second item, amount should stack up
+        // When adding the second item, the amount should stack up
         inventory.addItem(item2);
-        assertEquals(1001, inventory.getItemAmount(item));
+        assertThat(inventory.getItemAmount(item)).isEqualTo(1001);
     }
 
     @Test
@@ -165,8 +164,8 @@ public class InventoryImplTest {
         inventory.addItem(item);
         inventory.setCapacity(1);
 
-        assertEquals(1, inventory.getCapacity());
-        assertEquals(item, inventory.getItem(0));
+        assertThat(inventory.getCapacity()).isEqualTo(1);
+        assertThat(inventory.getItem(0)).isEqualTo(item);
 
         // TODO Test when capacity is trimmed and items are droped
     }
@@ -181,8 +180,8 @@ public class InventoryImplTest {
 
         inventory.cleanup();
 
-        assertEquals(-1, inventory.hasItem(item));
-        assertThat(inventory.hasItem(item2), not(equalTo(-1)));
+        assertThat(inventory.hasItem(item)).isEqualTo(-1);
+        assertThat(inventory.hasItem(item2)).isNotEqualTo(-1);
     }
 
 }

--- a/server/src/test/java/com/ao/model/map/PositionTest.java
+++ b/server/src/test/java/com/ao/model/map/PositionTest.java
@@ -20,17 +20,17 @@ public class PositionTest {
     @Test
     public void testAddToX() {
         pos.addToX(7);
-        assertThat(pos.getX()).isEqualTo(X_POSITION + 7);
+        assertThat(pos.getX()).isEqualTo((byte) (X_POSITION + 7));
         pos.addToX(-6);
-        assertThat(pos.getX()).isEqualTo(X_POSITION + 1);
+        assertThat(pos.getX()).isEqualTo((byte) (X_POSITION + 1));
     }
 
     @Test
     public void testAddToY() {
         pos.addToY(7);
-        assertThat(pos.getY()).isEqualTo(Y_POSITION + 7);
+        assertThat(pos.getY()).isEqualTo((byte) (Y_POSITION + 7));
         pos.addToY(-6);
-        assertThat(pos.getY()).isEqualTo(Y_POSITION + 1);
+        assertThat(pos.getY()).isEqualTo((byte) (Y_POSITION + 1));
     }
 
     @Test

--- a/server/src/test/java/com/ao/model/map/PositionTest.java
+++ b/server/src/test/java/com/ao/model/map/PositionTest.java
@@ -1,9 +1,9 @@
 package com.ao.model.map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PositionTest {
 
@@ -12,7 +12,7 @@ public class PositionTest {
 
     private Position pos;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         pos = new Position(X_POSITION, Y_POSITION, 1);
     }
@@ -20,34 +20,34 @@ public class PositionTest {
     @Test
     public void testAddToX() {
         pos.addToX(7);
-        assertEquals(X_POSITION + 7, pos.getX());
+        assertThat(pos.getX()).isEqualTo(X_POSITION + 7);
         pos.addToX(-6);
-        assertEquals(X_POSITION + 1, pos.getX());
+        assertThat(pos.getX()).isEqualTo(X_POSITION + 1);
     }
 
     @Test
     public void testAddToY() {
         pos.addToY(7);
-        assertEquals(Y_POSITION + 7, pos.getY());
+        assertThat(pos.getY()).isEqualTo(Y_POSITION + 7);
         pos.addToY(-6);
-        assertEquals(Y_POSITION + 1, pos.getY());
+        assertThat(pos.getY()).isEqualTo(Y_POSITION + 1);
     }
 
     @Test
     public void testGetDistance() {
         Position anotherPos = new Position((byte) (X_POSITION + 20), (byte) (Y_POSITION + 20), 1);
-        assertEquals(40, pos.getDistance(anotherPos));
+        assertThat(pos.getDistance(anotherPos)).isEqualTo(40);
     }
 
     @Test
     public void testInVisionRange() {
         Position anotherPos = new Position((byte) (X_POSITION + 20), (byte) (Y_POSITION + 20), pos.getMap());
-        assertFalse(pos.inVisionRange(anotherPos));
+        assertThat(pos.inVisionRange(anotherPos)).isFalse();
         anotherPos.setX((byte) (X_POSITION + 5));
         anotherPos.setY((byte) (Y_POSITION + 5));
-        assertTrue(pos.inVisionRange(anotherPos));
+        assertThat(pos.inVisionRange(anotherPos)).isTrue();
         anotherPos.setMap(2);
-        assertFalse(pos.inVisionRange(anotherPos));
+        assertThat(pos.inVisionRange(anotherPos)).isFalse();
     }
 
 }

--- a/server/src/test/java/com/ao/model/map/WorldMapTest.java
+++ b/server/src/test/java/com/ao/model/map/WorldMapTest.java
@@ -1,21 +1,20 @@
 package com.ao.model.map;
 
 import com.ao.model.character.Character;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 
 public class WorldMapTest {
 
     private WorldMap map;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         map = new WorldMap("foo", 1, (short) 1, new Tile[]{});
     }
@@ -28,9 +27,9 @@ public class WorldMapTest {
 
         map = new WorldMap("foo", 1, (short) 1, new Tile[]{t, t2, t3});
 
-        assertEquals(map.getTile(0, 0), t);
-        assertEquals(map.getTile(1, 0), t2);
-        assertEquals(map.getTile(2, 0), t3);
+        assertThat(t).isEqualTo(map.getTile(0, 0));
+        assertThat(t2).isEqualTo(map.getTile(1, 0));
+        assertThat(t3).isEqualTo(map.getTile(2, 0));
     }
 
     @Test
@@ -41,24 +40,25 @@ public class WorldMapTest {
         final WorldMap map5 = new WorldMap("asd", 3, (short) 1, new Tile[]{null});
         final WorldMap map6 = new WorldMap(null, 4, (short) 1, new Tile[]{});
 
-        assertEquals(map, map);
-        assertEquals(map2, map);
-        assertThat(map, not(equalTo(map3)));
-        assertThat(map, not(equalTo(map4)));
-        assertThat(map, not(equalTo(map5)));
-        assertThat(map6, not(equalTo(map)));
-        assertThat(map, not(equalTo(null)));
-        assertThat(map, not(equalTo(new String())));
+        assertThat(map).isEqualTo(map);
+        assertThat(map).isEqualTo(map2);
+        assertThat(map).isNotEqualTo(map3);
+        assertThat(map).isNotEqualTo(map3);
+        assertThat(map).isNotEqualTo(map4);
+        assertThat(map).isNotEqualTo(map5);
+        assertThat(map6).isNotEqualTo(map);
+        assertThat(map).isNotEqualTo(null);
+        assertThat(map).isNotEqualTo(new String());
     }
 
     @Test
     public void testGetName() {
-        assertEquals("foo", map.getName());
+        assertThat(map.getName()).isEqualTo("foo");
     }
 
     @Test
     public void testGetId() {
-        assertEquals(1, map.getId());
+        assertThat(map.getId()).isEqualTo(1);
     }
 
     @Test
@@ -78,12 +78,12 @@ public class WorldMapTest {
 
         final List<Character> chars = map.getCharactersNearby(7, 7);
 
-        assertEquals(5, chars.size());
-        assertThat(chars, hasItem(map.getTile(8, 8).getCharacter()));
-        assertThat(chars, hasItem(map.getTile(15, 8).getCharacter()));
-        assertThat(chars, hasItem(map.getTile(8, 15).getCharacter()));
-        assertThat(chars, hasItem(map.getTile(15, 15).getCharacter()));
-        assertThat(chars, hasItem(map.getTile(5, 5).getCharacter()));
+        assertThat(chars.size()).isEqualTo(5);
+        assertThat(chars).contains(map.getTile(8, 8).getCharacter());
+        assertThat(chars).contains(map.getTile(15, 8).getCharacter());
+        assertThat(chars).contains(map.getTile(8, 15).getCharacter());
+        assertThat(chars).contains(map.getTile(15, 15).getCharacter());
+        assertThat(chars).contains(map.getTile(5, 5).getCharacter());
     }
 
 }

--- a/server/src/test/java/com/ao/model/map/WorldMapTest.java
+++ b/server/src/test/java/com/ao/model/map/WorldMapTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 
 public class WorldMapTest {

--- a/server/src/test/java/com/ao/model/spell/SpellTest.java
+++ b/server/src/test/java/com/ao/model/spell/SpellTest.java
@@ -5,11 +5,12 @@ import com.ao.mock.MockFactory;
 import com.ao.model.character.Character;
 import com.ao.model.spell.effect.Effect;
 import com.ao.model.worldobject.WorldObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -29,7 +30,7 @@ public class SpellTest {
     private Spell spellWithStaff;
     private Spell spellNoStaffObject;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final Effect[] effects = new Effect[2];
         effects[0] = MockFactory.mockEffect(true, false);
@@ -52,30 +53,30 @@ public class SpellTest {
 
     @Test
     public void testRequiresStaff() {
-        assertFalse(spellNoStaff.requiresStaff());
-        assertTrue(spellWithStaff.requiresStaff());
-        assertFalse(spellNoStaffObject.requiresStaff());
+        assertThat(spellNoStaff.requiresStaff()).isFalse();
+        assertThat(spellWithStaff.requiresStaff()).isTrue();
+        assertThat(spellNoStaffObject.requiresStaff()).isFalse();
     }
 
     @Test
     public void testGetRequiredStaffPower() {
-        assertEquals(0, spellNoStaff.getRequiredStaffPower());
-        assertEquals(REQUIRED_STAFF_POWER, spellWithStaff.getRequiredStaffPower());
-        assertEquals(0, spellNoStaffObject.getRequiredStaffPower());
+        assertThat(spellNoStaff.getRequiredStaffPower()).isEqualTo(0);
+        assertThat(spellWithStaff.getRequiredStaffPower()).isEqualTo(REQUIRED_STAFF_POWER);
+        assertThat(spellNoStaffObject.getRequiredStaffPower()).isEqualTo(0);
     }
 
     @Test
     public void testGetRequiredMana() {
-        assertEquals(REQUIRED_MANA, spellNoStaff.getRequiredMana());
-        assertEquals(REQUIRED_MANA, spellWithStaff.getRequiredMana());
-        assertEquals(REQUIRED_MANA, spellNoStaffObject.getRequiredMana());
+        assertThat(spellNoStaff.getRequiredMana()).isEqualTo(REQUIRED_MANA);
+        assertThat(spellWithStaff.getRequiredMana()).isEqualTo(REQUIRED_MANA);
+        assertThat(spellNoStaffObject.getRequiredMana()).isEqualTo(REQUIRED_MANA);
     }
 
     @Test
     public void testGetRequiredSkill() {
-        assertEquals(REQUIRED_SKILL, spellNoStaff.getRequiredSkill());
-        assertEquals(REQUIRED_SKILL, spellWithStaff.getRequiredSkill());
-        assertEquals(REQUIRED_SKILL, spellNoStaffObject.getRequiredSkill());
+        assertThat(spellNoStaff.getRequiredSkill()).isEqualTo(REQUIRED_SKILL);
+        assertThat(spellWithStaff.getRequiredSkill()).isEqualTo(REQUIRED_SKILL);
+        assertThat(spellNoStaffObject.getRequiredSkill()).isEqualTo(REQUIRED_SKILL);
     }
 
     @Test
@@ -83,9 +84,9 @@ public class SpellTest {
         final Character caster = MockFactory.mockCharacter();
         final Character target = MockFactory.mockCharacter();
 
-        assertTrue(spellNoStaff.appliesTo(caster, target));
-        assertTrue(spellWithStaff.appliesTo(caster, target));
-        assertFalse(spellNoStaffObject.appliesTo(caster, target));
+        assertThat(spellNoStaff.appliesTo(caster, target)).isTrue();
+        assertThat(spellWithStaff.appliesTo(caster, target)).isTrue();
+        assertThat(spellNoStaffObject.appliesTo(caster, target)).isFalse();
     }
 
     @Test
@@ -93,9 +94,9 @@ public class SpellTest {
         final Character caster = MockFactory.mockCharacter();
         final WorldObject target = MockFactory.mockWorldObject();
 
-        assertFalse(spellNoStaff.appliesTo(caster, target));
-        assertFalse(spellWithStaff.appliesTo(caster, target));
-        assertTrue(spellNoStaffObject.appliesTo(caster, target));
+        assertThat(spellNoStaff.appliesTo(caster, target)).isFalse();
+        assertThat(spellWithStaff.appliesTo(caster, target)).isFalse();
+        assertThat(spellNoStaffObject.appliesTo(caster, target)).isTrue();
     }
 
     @Test
@@ -147,44 +148,44 @@ public class SpellTest {
 
     @Test
     public void testGetName() {
-        assertEquals(SPELL_NAME, spellNoStaff.getName());
-        assertEquals(SPELL_NAME, spellWithStaff.getName());
-        assertEquals(SPELL_NAME, spellNoStaffObject.getName());
+        assertThat(spellNoStaff.getName()).isEqualTo(SPELL_NAME);
+        assertThat(spellWithStaff.getName()).isEqualTo(SPELL_NAME);
+        assertThat(spellNoStaffObject.getName()).isEqualTo(SPELL_NAME);
     }
 
     @Test
     public void testGetDescription() {
-        assertEquals(SPELL_DESCRIPTION, spellNoStaff.getDescription());
-        assertEquals(SPELL_DESCRIPTION, spellWithStaff.getDescription());
-        assertEquals(SPELL_DESCRIPTION, spellNoStaffObject.getDescription());
+        assertThat(spellNoStaff.getDescription()).isEqualTo(SPELL_DESCRIPTION);
+        assertThat(spellWithStaff.getDescription()).isEqualTo(SPELL_DESCRIPTION);
+        assertThat(spellNoStaffObject.getDescription()).isEqualTo(SPELL_DESCRIPTION);
     }
 
     @Test
     public void testIsNegative() {
-        assertEquals(IS_NEGATIVE, spellNoStaff.isNegative());
-        assertEquals(IS_NEGATIVE, spellWithStaff.isNegative());
-        assertEquals(IS_NEGATIVE, spellNoStaffObject.isNegative());
+        assertThat(spellNoStaff.isNegative()).isEqualTo(IS_NEGATIVE);
+        assertThat(spellWithStaff.isNegative()).isEqualTo(IS_NEGATIVE);
+        assertThat(spellNoStaffObject.isNegative()).isEqualTo(IS_NEGATIVE);
     }
 
     @Test
     public void testGetFX() {
-        assertEquals(SPELL_FX, spellNoStaff.getFX());
-        assertEquals(SPELL_FX, spellWithStaff.getFX());
-        assertEquals(SPELL_FX, spellNoStaffObject.getFX());
+        assertThat(spellNoStaff.getFX()).isEqualTo(SPELL_FX);
+        assertThat(spellWithStaff.getFX()).isEqualTo(SPELL_FX);
+        assertThat(spellNoStaffObject.getFX()).isEqualTo(SPELL_FX);
     }
 
     @Test
     public void testGetSound() {
-        assertEquals(SPELL_SOUND, spellNoStaff.getSound());
-        assertEquals(SPELL_SOUND, spellWithStaff.getSound());
-        assertEquals(SPELL_SOUND, spellNoStaffObject.getSound());
+        assertThat(spellNoStaff.getSound()).isEqualTo(SPELL_SOUND);
+        assertThat(spellWithStaff.getSound()).isEqualTo(SPELL_SOUND);
+        assertThat(spellNoStaffObject.getSound()).isEqualTo(SPELL_SOUND);
     }
 
     @Test
     public void testGetMagicWords() {
-        assertEquals(SPELL_MAGIC_WORDS, spellNoStaff.getMagicWords());
-        assertEquals(SPELL_MAGIC_WORDS, spellWithStaff.getMagicWords());
-        assertEquals(SPELL_MAGIC_WORDS, spellNoStaffObject.getMagicWords());
+        assertThat(spellNoStaff.getMagicWords()).isEqualTo(SPELL_MAGIC_WORDS);
+        assertThat(spellWithStaff.getMagicWords()).isEqualTo(SPELL_MAGIC_WORDS);
+        assertThat(spellNoStaffObject.getMagicWords()).isEqualTo(SPELL_MAGIC_WORDS);
     }
 
 }

--- a/server/src/test/java/com/ao/model/spell/effect/DumbEffectTest.java
+++ b/server/src/test/java/com/ao/model/spell/effect/DumbEffectTest.java
@@ -4,10 +4,11 @@ import com.ao.exception.InvalidTargetException;
 import com.ao.model.character.Character;
 import com.ao.model.character.UserCharacter;
 import com.ao.model.worldobject.WorldObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -15,7 +16,7 @@ public class DumbEffectTest {
 
     private DumbEffect dumbEffect;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         dumbEffect = new DumbEffect();
     }
@@ -33,14 +34,14 @@ public class DumbEffectTest {
         final Character target = mock(Character.class);
         final Character caster = mock(Character.class);
 
-        assertFalse(dumbEffect.appliesTo(caster, target));
+        assertThat(dumbEffect.appliesTo(caster, target)).isFalse();
 
         final Character deadUserTarget = mock(UserCharacter.class);
         when(deadUserTarget.isDead()).thenReturn(Boolean.TRUE);
         final Character aliveUserTarget = mock(UserCharacter.class);
 
-        assertTrue(dumbEffect.appliesTo(caster, aliveUserTarget));
-        assertFalse(dumbEffect.appliesTo(caster, deadUserTarget));
+        assertThat(dumbEffect.appliesTo(caster, aliveUserTarget)).isTrue();
+        assertThat(dumbEffect.appliesTo(caster, deadUserTarget)).isFalse();
     }
 
     @Test
@@ -48,7 +49,7 @@ public class DumbEffectTest {
         final Character caster = mock(Character.class);
         final WorldObject target = mock(WorldObject.class);
 
-        assertFalse(dumbEffect.appliesTo(caster, target));
+        assertThat(dumbEffect.appliesTo(caster, target)).isFalse();
     }
 
     @Test
@@ -60,7 +61,7 @@ public class DumbEffectTest {
             dumbEffect.apply(caster, obj);
             fail("Applying an effect for characters to a world object didn't fail.");
         } catch (InvalidTargetException e) {
-            // this is ok
+            // This is ok
         }
     }
 

--- a/server/src/test/java/com/ao/model/spell/effect/HitPointsEffectTest.java
+++ b/server/src/test/java/com/ao/model/spell/effect/HitPointsEffectTest.java
@@ -3,10 +3,11 @@ package com.ao.model.spell.effect;
 import com.ao.exception.InvalidTargetException;
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.WorldObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -18,7 +19,7 @@ public class HitPointsEffectTest {
     private HitPointsEffect hpEffect1;
     private HitPointsEffect hpEffect2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         hpEffect1 = new HitPointsEffect(MIN_POINTS, MAX_POINTS);
         hpEffect2 = new HitPointsEffect(-MAX_POINTS, -MIN_POINTS);
@@ -31,10 +32,10 @@ public class HitPointsEffectTest {
         final Character aliveTarget = mock(Character.class);
         final Character caster = mock(Character.class);
 
-        assertTrue(hpEffect1.appliesTo(caster, aliveTarget));
-        assertTrue(hpEffect2.appliesTo(caster, aliveTarget));
-        assertFalse(hpEffect1.appliesTo(caster, deadTarget));
-        assertFalse(hpEffect2.appliesTo(caster, deadTarget));
+        assertThat(hpEffect1.appliesTo(caster, aliveTarget)).isTrue();
+        assertThat(hpEffect2.appliesTo(caster, aliveTarget)).isTrue();
+        assertThat(hpEffect1.appliesTo(caster, deadTarget)).isFalse();
+        assertThat(hpEffect2.appliesTo(caster, deadTarget)).isFalse();
     }
 
     @Test
@@ -42,8 +43,8 @@ public class HitPointsEffectTest {
         final Character caster = mock(Character.class);
         final WorldObject target = mock(WorldObject.class);
 
-        assertFalse(hpEffect1.appliesTo(caster, target));
-        assertFalse(hpEffect2.appliesTo(caster, target));
+        assertThat(hpEffect1.appliesTo(caster, target)).isFalse();
+        assertThat(hpEffect2.appliesTo(caster, target)).isFalse();
     }
 
     @Test
@@ -56,7 +57,7 @@ public class HitPointsEffectTest {
             hpEffect1.apply(caster, obj);
             fail("Applying an effect for characters to a world object didn't fail.");
         } catch (final InvalidTargetException e) {
-            // this is ok
+            // This is ok
         }
     }
 

--- a/server/src/test/java/com/ao/model/spell/effect/ImmobilizationEffectTest.java
+++ b/server/src/test/java/com/ao/model/spell/effect/ImmobilizationEffectTest.java
@@ -3,17 +3,18 @@ package com.ao.model.spell.effect;
 import com.ao.exception.InvalidTargetException;
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.WorldObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 public class ImmobilizationEffectTest {
 
     private Effect immobilizationEffect;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         immobilizationEffect = new ImmobilizationEffect();
     }
@@ -32,10 +33,10 @@ public class ImmobilizationEffectTest {
         final Character deadTarget = mock(Character.class);
         when(deadTarget.isDead()).thenReturn(Boolean.TRUE);
         final Character aliveTarget = mock(Character.class);
-        // Paralyzing a dead char is invalid.
-        assertFalse(immobilizationEffect.appliesTo(caster, deadTarget));
-        /// Paralyzing an alive char is valid.
-        assertTrue(immobilizationEffect.appliesTo(caster, aliveTarget));
+        // Paralyzing a dead char is invalid
+        assertThat(immobilizationEffect.appliesTo(caster, deadTarget)).isFalse();
+        // Paralyzing a live char is valid
+        assertThat(immobilizationEffect.appliesTo(caster, aliveTarget)).isTrue();
     }
 
     @Test
@@ -43,7 +44,7 @@ public class ImmobilizationEffectTest {
         final WorldObject obj = mock(WorldObject.class);
         final Character caster = mock(Character.class);
         // Should always false, no matter what
-        assertFalse(immobilizationEffect.appliesTo(caster, obj));
+        assertThat(immobilizationEffect.appliesTo(caster, obj)).isFalse();
     }
 
     @Test

--- a/server/src/test/java/com/ao/model/spell/effect/InvisibilityEffectTest.java
+++ b/server/src/test/java/com/ao/model/spell/effect/InvisibilityEffectTest.java
@@ -5,17 +5,18 @@ import com.ao.model.character.Character;
 import com.ao.model.character.NPCCharacter;
 import com.ao.model.character.UserCharacter;
 import com.ao.model.worldobject.WorldObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 public class InvisibilityEffectTest {
 
     private Effect invisibilityEffect;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         invisibilityEffect = new InvisibilityEffect();
     }
@@ -37,20 +38,20 @@ public class InvisibilityEffectTest {
         final NPCCharacter target = mock(NPCCharacter.class);
 
         // Test invalid target
-        assertFalse(invisibilityEffect.appliesTo(caster, target));
+        assertThat(invisibilityEffect.appliesTo(caster, target)).isFalse();
 
         // Test dead target
-        assertFalse(invisibilityEffect.appliesTo(caster, deadUserTarget));
+        assertThat(invisibilityEffect.appliesTo(caster, deadUserTarget)).isFalse();
 
         // Test alive target
-        assertTrue(invisibilityEffect.appliesTo(caster, aliveUserTarget));
+        assertThat(invisibilityEffect.appliesTo(caster, aliveUserTarget)).isTrue();
     }
 
     @Test
     public void testAppliesToCharacterWorldObject() {
         final WorldObject obj = mock(WorldObject.class);
         final Character caster = mock(Character.class);
-        assertFalse(invisibilityEffect.appliesTo(caster, obj));
+        assertThat(invisibilityEffect.appliesTo(caster, obj)).isFalse();
     }
 
     @Test

--- a/server/src/test/java/com/ao/model/spell/effect/ParalysisEffectTest.java
+++ b/server/src/test/java/com/ao/model/spell/effect/ParalysisEffectTest.java
@@ -3,17 +3,18 @@ package com.ao.model.spell.effect;
 import com.ao.exception.InvalidTargetException;
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.WorldObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 public class ParalysisEffectTest {
 
     private Effect paralysisEffect;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         paralysisEffect = new ParalysisEffect();
     }
@@ -34,10 +35,10 @@ public class ParalysisEffectTest {
         final Character deadTarget = mock(Character.class);
         when(deadTarget.isDead()).thenReturn(Boolean.TRUE);
         final Character aliveTarget = mock(Character.class);
-        // Paralyzing a dead char is invalid.
-        assertFalse(paralysisEffect.appliesTo(caster, deadTarget));
-        // Paralyzing an alive char is valid.
-        assertTrue(paralysisEffect.appliesTo(caster, aliveTarget));
+        // Paralyzing a dead char is invalid
+        assertThat(paralysisEffect.appliesTo(caster, deadTarget)).isFalse();
+        // Paralyzing a live char is valid
+        assertThat(paralysisEffect.appliesTo(caster, aliveTarget)).isTrue();
     }
 
     @Test
@@ -45,7 +46,7 @@ public class ParalysisEffectTest {
         final WorldObject obj = mock(WorldObject.class);
         final Character caster = mock(Character.class);
         // Should always false, no matter what
-        assertFalse(paralysisEffect.appliesTo(caster, obj));
+        assertThat(paralysisEffect.appliesTo(caster, obj)).isFalse();
     }
 
     @Test
@@ -57,7 +58,7 @@ public class ParalysisEffectTest {
             paralysisEffect.apply(caster, obj);
             fail("Applying an effect for characters to a world object didn't fail.");
         } catch (final InvalidTargetException e) {
-            // this is ok
+            // This is ok
         }
     }
 

--- a/server/src/test/java/com/ao/model/spell/effect/PoisonEffectTest.java
+++ b/server/src/test/java/com/ao/model/spell/effect/PoisonEffectTest.java
@@ -3,17 +3,18 @@ package com.ao.model.spell.effect;
 import com.ao.exception.InvalidTargetException;
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.WorldObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 public class PoisonEffectTest {
 
     private Effect poisonEffect;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         poisonEffect = new PoisonEffect();
     }
@@ -34,11 +35,11 @@ public class PoisonEffectTest {
         final Character aliveTarget = mock(Character.class);
         when(deadTarget.isDead()).thenReturn(Boolean.TRUE);
 
-        // Paralyzing a dead char is invalid.
-        assertFalse(poisonEffect.appliesTo(caster, deadTarget));
+        // Paralyzing a dead char is invalid
+        assertThat(poisonEffect.appliesTo(caster, deadTarget)).isFalse();
 
-        /// Paralyzing an live char is valid.
-        assertTrue(poisonEffect.appliesTo(caster, aliveTarget));
+        // Paralyzing a live char is valid
+        assertThat(poisonEffect.appliesTo(caster, aliveTarget)).isTrue();
     }
 
     @Test
@@ -47,7 +48,7 @@ public class PoisonEffectTest {
         final Character caster = mock(Character.class);
 
         // Should always false, no matter what
-        assertFalse(poisonEffect.appliesTo(caster, obj));
+        assertThat(poisonEffect.appliesTo(caster, obj)).isFalse();
     }
 
     @Test
@@ -60,7 +61,7 @@ public class PoisonEffectTest {
             poisonEffect.apply(caster, obj);
             fail("Applying an effect for characters to a world object didn't fail.");
         } catch (final InvalidTargetException e) {
-            // this is ok
+            // This is ok
         }
     }
 

--- a/server/src/test/java/com/ao/model/spell/effect/RecoverMobilityEffectTest.java
+++ b/server/src/test/java/com/ao/model/spell/effect/RecoverMobilityEffectTest.java
@@ -3,17 +3,18 @@ package com.ao.model.spell.effect;
 import com.ao.exception.InvalidTargetException;
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.WorldObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 public class RecoverMobilityEffectTest {
 
     private Effect recoverMobilityEffect;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         recoverMobilityEffect = new RecoverMobilityEffect();
     }
@@ -33,31 +34,31 @@ public class RecoverMobilityEffectTest {
     public void testAppliesToCharacterCharacter() {
         final Character caster = mock(Character.class);
 
-        // An immobilized char is valid.
+        // An immobilized char is valid
         final Character immobilizedTarget = mock(Character.class);
         when(immobilizedTarget.isImmobilized()).thenReturn(Boolean.TRUE);
-        assertTrue(recoverMobilityEffect.appliesTo(caster, immobilizedTarget));
+        assertThat(recoverMobilityEffect.appliesTo(caster, immobilizedTarget)).isTrue();
 
-        // A paralyzed char is valid.
+        // A paralyzed char is valid
         final Character palayzedTarget = mock(Character.class);
         when(palayzedTarget.isParalyzed()).thenReturn(Boolean.TRUE);
-        assertTrue(recoverMobilityEffect.appliesTo(caster, palayzedTarget));
+        assertThat(recoverMobilityEffect.appliesTo(caster, palayzedTarget)).isTrue();
 
-        // A non-paralyzed, non/immobilized char is invalid.
+        // A non-paralyzed, non/immobilized char is invalid
         final Character normalTarget = mock(Character.class);
-        assertFalse(recoverMobilityEffect.appliesTo(caster, normalTarget));
+        assertThat(recoverMobilityEffect.appliesTo(caster, normalTarget)).isFalse();
 
-        // A paralyzed dead char is invalid.
+        // A paralyzed dead char is invalid
         final Character palayzedDeadTarget = mock(Character.class);
         when(palayzedDeadTarget.isParalyzed()).thenReturn(Boolean.TRUE);
         when(palayzedDeadTarget.isDead()).thenReturn(Boolean.TRUE);
-        assertFalse(recoverMobilityEffect.appliesTo(caster, palayzedDeadTarget));
+        assertThat(recoverMobilityEffect.appliesTo(caster, palayzedDeadTarget)).isFalse();
 
-        // A immobilized dead char is invalid.
+        // An immobilized dead char is invalid
         final Character immobilizedDeadTarget = mock(Character.class);
         when(immobilizedDeadTarget.isImmobilized()).thenReturn(Boolean.TRUE);
         when(immobilizedDeadTarget.isDead()).thenReturn(Boolean.TRUE);
-        assertFalse(recoverMobilityEffect.appliesTo(caster, immobilizedDeadTarget));
+        assertThat(recoverMobilityEffect.appliesTo(caster, immobilizedDeadTarget)).isFalse();
     }
 
     @Test
@@ -66,7 +67,7 @@ public class RecoverMobilityEffectTest {
         final Character caster = mock(Character.class);
 
         // Should always false, no matter what
-        assertFalse(recoverMobilityEffect.appliesTo(caster, obj));
+        assertThat(recoverMobilityEffect.appliesTo(caster, obj)).isFalse();
     }
 
     @Test

--- a/server/src/test/java/com/ao/model/user/AccountImplTest.java
+++ b/server/src/test/java/com/ao/model/user/AccountImplTest.java
@@ -1,12 +1,12 @@
 package com.ao.model.user;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AccountImplTest {
 
@@ -15,13 +15,13 @@ public class AccountImplTest {
     private static final String ACCOUNT_INVALID_PASSWORD = "invalid pass";
     private static final String ACCOUNT_EMAIL = "anemail@address.com";
     private static final boolean ACCOUNT_BANNED = false;
-    private static final Set<String> ACCOUNT_CHARACTERS = new HashSet<String>();
+    private static final Set<String> ACCOUNT_CHARACTERS = new HashSet<>();
     private static final String TEST_CHARACTER_NAME = "TEST";
     private static final String NON_EXISTING_CHARACTER_NAME = "non existing character";
 
     private AccountImpl account;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         account = new AccountImpl(ACCOUNT_NAME, ACCOUNT_PASSWORD, ACCOUNT_EMAIL, ACCOUNT_CHARACTERS, ACCOUNT_BANNED);
         account.characters.add(TEST_CHARACTER_NAME);
@@ -29,43 +29,43 @@ public class AccountImplTest {
 
     @Test
     public void testGetName() {
-        assertEquals(account.getName(), ACCOUNT_NAME);
+        assertThat(ACCOUNT_NAME).isEqualTo(account.getName()); // Se asegura de que el valor actual sea igual al valor esperado
     }
 
     @Test
     public void testGetMail() {
-        assertEquals(account.getMail(), ACCOUNT_EMAIL);
+        assertThat(ACCOUNT_EMAIL).isEqualTo(account.getMail());
     }
 
     @Test
     public void testGetCharacters() {
-        assertEquals(account.getCharacters(), ACCOUNT_CHARACTERS);
+        assertThat(ACCOUNT_CHARACTERS).isEqualTo(account.getCharacters());
     }
 
     @Test
     public void testHasCharacter() {
-        assertTrue(account.hasCharacter(TEST_CHARACTER_NAME));
-        assertFalse(account.hasCharacter(NON_EXISTING_CHARACTER_NAME));
+        assertThat(account.hasCharacter(TEST_CHARACTER_NAME)).isTrue();
+        assertThat(account.hasCharacter(NON_EXISTING_CHARACTER_NAME)).isFalse();
     }
 
     @Test
     public void testIsBanned() {
-        assertEquals(account.isBanned(), ACCOUNT_BANNED);
+        assertThat(ACCOUNT_BANNED).isEqualTo(account.isBanned());
         account.setBanned(!ACCOUNT_BANNED);
-        assertEquals(account.isBanned(), !ACCOUNT_BANNED);
+        assertThat(!ACCOUNT_BANNED).isEqualTo(account.isBanned());
     }
 
     @Test
     public void testAuthenticate() {
-        assertTrue(account.authenticate(ACCOUNT_PASSWORD));
-        assertFalse(account.authenticate(ACCOUNT_INVALID_PASSWORD));
+        assertThat(account.authenticate(ACCOUNT_PASSWORD)).isTrue();
+        assertThat(account.authenticate(ACCOUNT_INVALID_PASSWORD)).isFalse();
     }
 
     @Test
     public void testAddCharacter() {
         final String charr = "foo";
         account.addCharacter(charr);
-        assertTrue(account.characters.contains(charr));
+        assertThat(account.characters.contains(charr)).isTrue();
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/AbstractDefensiveItemTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/AbstractDefensiveItemTest.java
@@ -1,30 +1,30 @@
 package com.ao.model.worldobject;
 
 import com.ao.model.worldobject.properties.DefensiveItemProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractDefensiveItemTest extends AbstractEquipableItemTest {
 
     @Test
     public void testGetMaxDef() {
-        assertEquals(((DefensiveItemProperties) objectProps).getMaxDef(), ((AbstractDefensiveItem) object).getMaxDef());
+        assertThat(((AbstractDefensiveItem) object).getMaxDef()).isEqualTo(((DefensiveItemProperties) objectProps).getMaxDef());
     }
 
     @Test
     public void testGetMinDef() {
-        assertEquals(((DefensiveItemProperties) objectProps).getMinDef(), ((AbstractDefensiveItem) object).getMinDef());
+        assertThat(((AbstractDefensiveItem) object).getMinDef()).isEqualTo(((DefensiveItemProperties) objectProps).getMinDef());
     }
 
     @Test
     public void testGetMaxMagicDef() {
-        assertEquals(((DefensiveItemProperties) objectProps).getMaxMagicDef(), ((AbstractDefensiveItem) object).getMaxMagicDef());
+        assertThat(((AbstractDefensiveItem) object).getMaxMagicDef()).isEqualTo(((DefensiveItemProperties) objectProps).getMaxMagicDef());
     }
 
     @Test
     public void testGetMinMagicDef() {
-        assertEquals(((DefensiveItemProperties) objectProps).getMinMagicDef(), ((AbstractDefensiveItem) object).getMinMagicDef());
+        assertThat(((AbstractDefensiveItem) object).getMinMagicDef()).isEqualTo(((DefensiveItemProperties) objectProps).getMinMagicDef());
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/AbstractEquipableItemTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/AbstractEquipableItemTest.java
@@ -1,9 +1,9 @@
 package com.ao.model.worldobject;
 
 import com.ao.model.worldobject.properties.EquippableItemProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractEquipableItemTest extends AbstractItemTest {
 
@@ -11,21 +11,21 @@ public abstract class AbstractEquipableItemTest extends AbstractItemTest {
 
     @Test
     public void testGetEquippedGraphic() {
-        assertEquals(((EquippableItemProperties) objectProps).getEquippedGraphic(), ((AbstractEquipableItem) object).getEquippedGraphic());
+        assertThat(((AbstractEquipableItem) object).getEquippedGraphic()).isEqualTo(((EquippableItemProperties) objectProps).getEquippedGraphic());
     }
 
     @Test
     public void testIsEquipped() {
-        assertEquals(itemEquipped, ((AbstractEquipableItem) object).isEquipped());
+        assertThat(((AbstractEquipableItem) object).isEquipped()).isEqualTo(itemEquipped);
     }
 
     @Test
     public void testSetEquipped() {
         final AbstractEquipableItem it = (AbstractEquipableItem) object;
         it.setEquipped(false);
-        assertEquals(false, it.isEquipped());
+        assertThat(it.isEquipped()).isFalse();
         it.setEquipped(true);
-        assertEquals(true, it.isEquipped());
+        assertThat(it.isEquipped()).isTrue();
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/AbstractItemTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/AbstractItemTest.java
@@ -1,10 +1,9 @@
 package com.ao.model.worldobject;
 
 import com.ao.model.worldobject.properties.ItemProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractItemTest extends AbstractWorldObjectTest {
 
@@ -18,59 +17,59 @@ public abstract class AbstractItemTest extends AbstractWorldObjectTest {
         // Check adding and removing
         if (ammount < AbstractItem.MAX_STACKED_ITEMS) {
             item.addAmount(1);
-            assertEquals(ammount + 1, item.getAmount());
+            assertThat(item.getAmount()).isEqualTo(ammount + 1);
             item.addAmount(-1);
-            assertEquals(ammount, item.getAmount());
+            assertThat(item.getAmount()).isEqualTo(ammount);
         } else {
             item.addAmount(-1);
-            assertEquals(ammount - 1, item.getAmount());
+            assertThat(item.getAmount()).isEqualTo(ammount - 1);
             item.addAmount(1);
-            assertEquals(ammount, item.getAmount());
+            assertThat(item.getAmount()).isEqualTo(ammount);
         }
 
         // Check limits
         item.addAmount(AbstractItem.MAX_STACKED_ITEMS + 1);
-        assertEquals(AbstractItem.MAX_STACKED_ITEMS, item.getAmount());
+        assertThat(item.getAmount()).isEqualTo(AbstractItem.MAX_STACKED_ITEMS);
     }
 
     @Test
     public void testGetValue() {
         final AbstractItem item = (AbstractItem) object;
         final ItemProperties itemProps = (ItemProperties) objectProps;
-        assertEquals(itemProps.getValue(), item.getValue());
+        assertThat(item.getValue()).isEqualTo(itemProps.getValue());
     }
 
     @Test
     public void testIsNewbie() {
         final AbstractItem item = (AbstractItem) object;
         final ItemProperties itemProps = (ItemProperties) objectProps;
-        assertEquals(itemProps.isNewbie(), item.isNewbie());
+        assertThat(item.isNewbie()).isEqualTo(itemProps.isNewbie());
     }
 
     @Test
     public void testCanBeStolen() {
         final AbstractItem item = (AbstractItem) object;
-        assertTrue(item.canBeStolen());
+        assertThat(item.canBeStolen()).isTrue();
     }
 
     @Test
     public void testIsNoLog() {
         final AbstractItem item = (AbstractItem) object;
         final ItemProperties itemProps = (ItemProperties) objectProps;
-        assertEquals(itemProps.isNoLog(), item.isNoLog());
+        assertThat(item.isNoLog()).isEqualTo(itemProps.isNoLog());
     }
 
     public void testIsFalls() {
         final AbstractItem item = (AbstractItem) object;
         final ItemProperties itemProps = (ItemProperties) objectProps;
-        assertEquals(itemProps.isFalls(), item.isFalls());
+        assertThat(item.isFalls()).isEqualTo(itemProps.isFalls());
     }
 
     @Test
     public void testIsRespawneable() {
         final AbstractItem item = (AbstractItem) object;
         final ItemProperties itemProps = (ItemProperties) objectProps;
-        assertEquals(itemProps.isRespawnable(), item.isRespawnable());
+        assertThat(item.isRespawnable()).isEqualTo(itemProps.isRespawnable());
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/AbstractResourceSourceTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/AbstractResourceSourceTest.java
@@ -1,15 +1,15 @@
 package com.ao.model.worldobject;
 
 import com.ao.model.worldobject.properties.ResourceSourceProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractResourceSourceTest extends AbstractWorldObjectTest {
 
     @Test
     public void testResourceWorldObjctId() {
-        assertEquals(((ResourceSourceProperties) objectProps).getResourceWorldObjctId(), ((AbstractResourceSource) object).getResourceWorldObjctId());
+        assertThat(((AbstractResourceSource) object).getResourceWorldObjctId()).isEqualTo(((ResourceSourceProperties) objectProps).getResourceWorldObjctId());
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/AbstractWorldObjectTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/AbstractWorldObjectTest.java
@@ -1,9 +1,9 @@
 package com.ao.model.worldobject;
 
 import com.ao.model.worldobject.properties.WorldObjectProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractWorldObjectTest {
 
@@ -12,17 +12,17 @@ public abstract class AbstractWorldObjectTest {
 
     @Test
     public void testGetId() {
-        assertEquals(objectProps.getId(), object.getId());
+        assertThat(object.getId()).isEqualTo(objectProps.getId());
     }
 
     @Test
     public void testGetGraphic() {
-        assertEquals(objectProps.getGraphic(), object.getGraphic());
+        assertThat(object.getGraphic()).isEqualTo(objectProps.getGraphic());
     }
 
     @Test
     public void testGetName() {
-        assertEquals(objectProps.getName(), object.getName());
+        assertThat(object.getName()).isEqualTo(objectProps.getName());
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/AccessoryTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/AccessoryTest.java
@@ -2,11 +2,10 @@ package com.ao.model.worldobject;
 
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.properties.DefensiveItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class AccessoryTest extends AbstractDefensiveItemTest {
@@ -20,7 +19,7 @@ public class AccessoryTest extends AbstractDefensiveItemTest {
     private Accessory accessory1;
     private Accessory accessory2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final DefensiveItemProperties props1 = new DefensiveItemProperties(WorldObjectType.ACCESSORY, 1, "Gold Ring", 1, 1, 0, null, null, false, false, false, false, 1, MIN_DEF, MAX_DEF, MIN_MAGIC_DEF, MAX_MAGIC_DEF);
         accessory1 = new Accessory(props1, 5);
@@ -39,20 +38,20 @@ public class AccessoryTest extends AbstractDefensiveItemTest {
         final Accessory clone = (Accessory) accessory1.clone();
 
         // Make sure all fields match
-        assertEquals(accessory1.amount, clone.amount);
-        assertEquals(accessory1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(accessory1.amount);
+        assertThat(clone.properties).isEqualTo(accessory1.properties);
 
-        // Make sure the object itself is different
-        assertNotSame(accessory1, clone);
+        // Make sure the object itself is different 
+        assertThat(clone).isNotSameAs(accessory1);
 
         final Accessory clone2 = (Accessory) accessory2.clone();
 
         // Make sure all fields match
-        assertEquals(accessory2.amount, clone2.amount);
-        assertEquals(accessory2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(accessory2.amount);
+        assertThat(clone2.properties).isEqualTo(accessory2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(accessory2, clone2);
+        assertThat(clone2).isNotSameAs(accessory2);
     }
 
     @Test

--- a/server/src/test/java/com/ao/model/worldobject/AmmunitionTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/AmmunitionTest.java
@@ -2,12 +2,10 @@ package com.ao.model.worldobject;
 
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.properties.AmmunitionProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class AmmunitionTest extends AbstractEquipableItemTest {
@@ -18,7 +16,7 @@ public class AmmunitionTest extends AbstractEquipableItemTest {
     protected Ammunition ammunition1;
     protected Ammunition ammunition2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final AmmunitionProperties props1 = new AmmunitionProperties(WorldObjectType.AMMUNITION, 1, "Arrow", 1, 1, null, null, false, false, false, false, 1, MIN_HIT, MAX_HIT);
         ammunition1 = new Ammunition(props1, 5);
@@ -37,27 +35,25 @@ public class AmmunitionTest extends AbstractEquipableItemTest {
         final Ammunition clone = (Ammunition) ammunition1.clone();
 
         // Make sure all fields match
-        assertEquals(ammunition1.amount, clone.amount);
-        assertEquals(ammunition1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(ammunition1.amount); // Se asegura que el valor actual sea igual al valor esperado
+        assertThat(clone.properties).isEqualTo(ammunition1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(ammunition1, clone);
-
+        assertThat(clone).isNotSameAs(ammunition1);
 
         final Ammunition clone2 = (Ammunition) ammunition2.clone();
 
         // Make sure all fields match
-        assertEquals(ammunition2.amount, clone2.amount);
-        assertEquals(ammunition2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(ammunition2.amount);
+        assertThat(clone2.properties).isEqualTo(ammunition2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(ammunition2, clone2);
+        assertThat(clone2).isNotSameAs(ammunition2);
     }
 
     @Test
     public void testUse() {
         final Character character = mock(Character.class);
-
         // nothing should happen
         ammunition1.use(character);
         ammunition2.use(character);
@@ -65,23 +61,21 @@ public class AmmunitionTest extends AbstractEquipableItemTest {
 
     @Test
     public void testGetMinHit() {
-        assertEquals(MIN_HIT, ammunition1.getMinHit());
-        assertEquals(MAX_HIT, ammunition2.getMinHit());
+        assertThat(ammunition1.getMinHit()).isEqualTo(MIN_HIT);
+        assertThat(ammunition2.getMinHit()).isEqualTo(MAX_HIT);
     }
 
     @Test
     public void testGetMaxHit() {
-        assertEquals(MAX_HIT, ammunition1.getMaxHit());
-        assertEquals(MAX_HIT, ammunition2.getMaxHit());
+        assertThat(ammunition1.getMaxHit()).isEqualTo(MAX_HIT);
+        assertThat(ammunition2.getMaxHit()).isEqualTo(MAX_HIT);
     }
 
     @Test
     public void testGetDamage() {
         final int damage = ammunition1.getDamage();
-
-        assertThat(damage, greaterThanOrEqualTo(MIN_HIT));
-        assertThat(damage, lessThanOrEqualTo(MAX_HIT));
-        assertEquals(MAX_HIT, ammunition2.getDamage());
+        assertThat(damage).isBetween(MIN_HIT, MAX_HIT);
+        assertThat(ammunition2.getDamage()).isEqualTo(MAX_HIT);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/ArmorTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/ArmorTest.java
@@ -2,11 +2,10 @@ package com.ao.model.worldobject;
 
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.properties.DefensiveItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class ArmorTest extends AbstractDefensiveItemTest {
@@ -20,7 +19,7 @@ public class ArmorTest extends AbstractDefensiveItemTest {
     private Armor armor1;
     private Armor armor2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final DefensiveItemProperties props1 = new DefensiveItemProperties(WorldObjectType.ARMOR, 1, "Leather Armor", 1, 1, 0, null, null, false, false, false, false, 1, MIN_DEF, MAX_DEF, MIN_MAGIC_DEF, MAX_MAGIC_DEF);
         armor1 = new Armor(props1, 5);
@@ -39,21 +38,21 @@ public class ArmorTest extends AbstractDefensiveItemTest {
         final Armor clone = (Armor) armor1.clone();
 
         // Make sure all fields match
-        assertEquals(armor1.amount, clone.amount);
-        assertEquals(armor1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(armor1.amount);
+        assertThat(clone.properties).isEqualTo(armor1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(armor1, clone);
+        assertThat(clone).isNotSameAs(armor1);
 
 
         final Armor clone2 = (Armor) armor2.clone();
 
         // Make sure all fields match
-        assertEquals(armor2.amount, clone2.amount);
-        assertEquals(armor2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(armor2.amount);
+        assertThat(clone2.properties).isEqualTo(armor2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(armor2, clone2);
+        assertThat(clone2).isNotSameAs(armor2);
     }
 
     @Test

--- a/server/src/test/java/com/ao/model/worldobject/BoatTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/BoatTest.java
@@ -2,12 +2,10 @@ package com.ao.model.worldobject;
 
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.properties.BoatProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class BoatTest extends AbstractDefensiveItemTest {
@@ -25,7 +23,7 @@ public class BoatTest extends AbstractDefensiveItemTest {
     private Boat boat1;
     private Boat boat2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final BoatProperties props1 = new BoatProperties(WorldObjectType.BOAT, 1, "Small Boat", 1, 1, USAGE_DIFFICULTY, 0, null, null, false, false, false, false, 1, MIN_DEF, MAX_DEF, MIN_MAGIC_DEF, MAX_MAGIC_DEF, MIN_HIT, MAX_HIT);
         boat1 = new Boat(props1, 5);
@@ -44,21 +42,20 @@ public class BoatTest extends AbstractDefensiveItemTest {
         final Boat clone = (Boat) boat1.clone();
 
         // Make sure all fields match
-        assertEquals(boat1.amount, clone.amount);
-        assertEquals(boat1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(boat1.amount);
+        assertThat(clone.properties).isEqualTo(boat1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(boat1, clone);
-
+        assertThat(clone).isNotSameAs(boat1);
 
         final Boat clone2 = (Boat) boat2.clone();
 
         // Make sure all fields match
-        assertEquals(boat2.amount, clone2.amount);
-        assertEquals(boat2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(boat2.amount);
+        assertThat(clone2.properties).isEqualTo(boat2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(boat2, clone2);
+        assertThat(clone2).isNotSameAs(boat2);
     }
 
     @Test
@@ -72,35 +69,34 @@ public class BoatTest extends AbstractDefensiveItemTest {
 
     @Test
     public void testGetMinHit() {
-        assertEquals(MIN_HIT, boat1.getMinHit());
-        assertEquals(MAX_HIT, boat2.getMinHit());
+        assertThat(boat1.getMinHit()).isEqualTo(MIN_HIT);
+        assertThat(boat2.getMinHit()).isEqualTo(MAX_HIT);
     }
 
     @Test
     public void testGetMaxHit() {
-        assertEquals(MAX_HIT, boat1.getMaxHit());
-        assertEquals(MAX_HIT, boat2.getMaxHit());
+        assertThat(boat1.getMaxHit()).isEqualTo(MAX_HIT);
+        assertThat(boat2.getMaxHit()).isEqualTo(MAX_HIT);
     }
 
     @Test
     public void testGetDamageBonus() {
         final int damage = boat1.getDamageBonus();
 
-        assertThat(damage, greaterThanOrEqualTo(MIN_HIT));
-        assertThat(damage, lessThanOrEqualTo(MAX_HIT));
-        assertEquals(MAX_HIT, boat2.getDamageBonus());
+        assertThat(damage).isBetween(MIN_HIT, MAX_HIT);
+        assertThat(boat2.getDamageBonus()).isEqualTo(MAX_HIT);
     }
 
     @Test
     @Override
     public void testCanBeStolen() {
-        assertFalse(boat1.canBeStolen());
-        assertFalse(boat2.canBeStolen());
+        assertThat(boat1.canBeStolen()).isFalse();
+        assertThat(boat2.canBeStolen()).isFalse();
     }
 
     @Test
     public void testGetUsageDifficulty() {
-        assertEquals(USAGE_DIFFICULTY, boat1.getUsageDifficulty());
-        assertEquals(USAGE_DIFFICULTY, boat2.getUsageDifficulty());
+        assertThat(boat1.getUsageDifficulty()).isEqualTo(USAGE_DIFFICULTY);
+        assertThat(boat2.getUsageDifficulty()).isEqualTo(USAGE_DIFFICULTY);
     }
 }

--- a/server/src/test/java/com/ao/model/worldobject/DeathPotionTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/DeathPotionTest.java
@@ -3,11 +3,10 @@ package com.ao.model.worldobject;
 import com.ao.model.character.Character;
 import com.ao.model.inventory.Inventory;
 import com.ao.model.worldobject.properties.ItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class DeathPotionTest extends AbstractItemTest {
@@ -17,7 +16,7 @@ public class DeathPotionTest extends AbstractItemTest {
     private DeathPotion potion1;
     private DeathPotion potion2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final ItemProperties props1 = new ItemProperties(WorldObjectType.DEATH_POTION, 1, "Black Potion", 1, 1, null, null, false, false, false, true);
         potion1 = new DeathPotion(props1, 5);
@@ -62,21 +61,21 @@ public class DeathPotionTest extends AbstractItemTest {
         final DeathPotion clone = (DeathPotion) potion1.clone();
 
         // Make sure all fields match
-        assertEquals(potion1.amount, clone.amount);
-        assertEquals(potion1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(potion1.amount);
+        assertThat(clone.properties).isEqualTo(potion1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(potion1, clone);
+        assertThat(clone).isNotSameAs(potion1);
 
 
         final DeathPotion clone2 = (DeathPotion) potion2.clone();
 
         // Make sure all fields match
-        assertEquals(potion2.amount, clone2.amount);
-        assertEquals(potion2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(potion2.amount);
+        assertThat(clone2.properties).isEqualTo(potion2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(potion2, clone2);
+        assertThat(clone2).isNotSameAs(potion2);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/DexterityPotionTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/DexterityPotionTest.java
@@ -3,13 +3,11 @@ package com.ao.model.worldobject;
 import com.ao.model.character.Character;
 import com.ao.model.inventory.Inventory;
 import com.ao.model.worldobject.properties.TemporalStatModifyingItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class DexterityPotionTest extends AbstractItemTest {
@@ -21,7 +19,7 @@ public class DexterityPotionTest extends AbstractItemTest {
     private DexterityPotion potion1;
     private DexterityPotion potion2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final TemporalStatModifyingItemProperties props1 = new TemporalStatModifyingItemProperties(WorldObjectType.POISON_POTION, 1, "Yellow Potion", 1, 1, null, null, false, false, false, false, MIN_AGI, MAX_AGI, DURATION);
         potion1 = new DexterityPotion(props1, 5);
@@ -58,20 +56,19 @@ public class DexterityPotionTest extends AbstractItemTest {
         /// Make sure the value is in the correct range
         final ArgumentCaptor<Integer> capture = ArgumentCaptor.forClass(Integer.class);
         verify(character).addToDexterity(capture.capture(), eq(DURATION));
-        assertThat(capture.getValue(), greaterThanOrEqualTo(MIN_AGI));
-        assertThat(capture.getValue(), lessThanOrEqualTo(MAX_AGI));
+        assertThat(capture.getValue()).isBetween(MIN_AGI, MAX_AGI);
     }
 
     @Test
     public void testGetMinModifier() {
-        assertEquals(MIN_AGI, potion1.getMinModifier());
-        assertEquals(MAX_AGI, potion2.getMinModifier());
+        assertThat(potion1.getMinModifier()).isEqualTo(MIN_AGI);
+        assertThat(potion2.getMinModifier()).isEqualTo(MAX_AGI);
     }
 
     @Test
     public void testGetMaxModifier() {
-        assertEquals(MAX_AGI, potion1.getMaxModifier());
-        assertEquals(MAX_AGI, potion2.getMaxModifier());
+        assertThat(potion1.getMaxModifier()).isEqualTo(MAX_AGI);
+        assertThat(potion2.getMaxModifier()).isEqualTo(MAX_AGI);
     }
 
     @Test
@@ -79,26 +76,26 @@ public class DexterityPotionTest extends AbstractItemTest {
         final DexterityPotion clone = (DexterityPotion) potion1.clone();
 
         // Make sure all fields match
-        assertEquals(potion1.amount, clone.amount);
-        assertEquals(potion1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(potion1.amount);
+        assertThat(clone.properties).isEqualTo(potion1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(potion1, clone);
-
+        assertThat(clone).isNotSameAs(potion1);
 
         final DexterityPotion clone2 = (DexterityPotion) potion2.clone();
 
         // Make sure all fields match
-        assertEquals(potion2.amount, clone2.amount);
-        assertEquals(potion2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(potion2.amount);
+        assertThat(clone2.properties).isEqualTo(potion2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(potion2, clone2);
+        assertThat(clone2).isNotSameAs(potion2);
     }
 
     @Test
     public void testGetEffectDuration() {
-        assertEquals(DURATION, potion1.getEffectDuration());
-        assertEquals(DURATION, potion2.getEffectDuration());
+        assertThat(potion1.getEffectDuration()).isEqualTo(DURATION);
+        assertThat(potion2.getEffectDuration()).isEqualTo(DURATION);
     }
+
 }

--- a/server/src/test/java/com/ao/model/worldobject/DoorTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/DoorTest.java
@@ -1,10 +1,10 @@
 package com.ao.model.worldobject;
 
 import com.ao.model.worldobject.properties.DoorProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DoorTest extends AbstractWorldObjectTest {
 
@@ -15,7 +15,7 @@ public class DoorTest extends AbstractWorldObjectTest {
 
     private Door door1;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final DoorProperties props1 = new DoorProperties(WorldObjectType.DOOR, 1, "Puerta abierta", 1, OPEN, LOCKED, CODE, OTHER_PROPERTIES);
         door1 = new Door(props1);
@@ -25,17 +25,17 @@ public class DoorTest extends AbstractWorldObjectTest {
 
     @Test
     public void testGetOpen() {
-        assertTrue(door1.getOpen());
+        assertThat(door1.getOpen()).isTrue();
     }
 
     @Test
     public void testGetLocked() {
-        assertFalse(door1.getLocked());
+        assertThat(door1.getLocked()).isFalse();
     }
 
     @Test
     public void testGetCode() {
-        assertEquals(CODE, door1.getCode());
+        assertThat(door1.getCode()).isEqualTo(CODE);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/DrinkTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/DrinkTest.java
@@ -3,13 +3,11 @@ package com.ao.model.worldobject;
 import com.ao.model.character.Character;
 import com.ao.model.inventory.Inventory;
 import com.ao.model.worldobject.properties.StatModifyingItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class DrinkTest extends AbstractItemTest {
@@ -20,7 +18,7 @@ public class DrinkTest extends AbstractItemTest {
     private Drink drink1;
     private Drink drink2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final StatModifyingItemProperties props1 = new StatModifyingItemProperties(WorldObjectType.FOOD, 1, "Apple Juice", 1, 1, null, null, false, false, false, false, MIN_THIRST, MAX_THIRST);
         drink1 = new Drink(props1, 5);
@@ -57,20 +55,19 @@ public class DrinkTest extends AbstractItemTest {
 
         /// Make sure the value is in the correct range
         verify(character).addToThirstiness(capture.capture());
-        assertThat(capture.getValue(), greaterThanOrEqualTo(MIN_THIRST));
-        assertThat(capture.getValue(), lessThanOrEqualTo(MAX_THIRST));
+        assertThat(capture.getValue()).isBetween(MIN_THIRST, MAX_THIRST);
     }
 
     @Test
     public void testGetMinThirst() {
-        assertEquals(MIN_THIRST, drink1.getMinThirst());
-        assertEquals(MAX_THIRST, drink2.getMinThirst());
+        assertThat(drink1.getMinThirst()).isEqualTo(MIN_THIRST);
+        assertThat(drink2.getMinThirst()).isEqualTo(MAX_THIRST);
     }
 
     @Test
     public void testGetMaxThirst() {
-        assertEquals(MAX_THIRST, drink1.getMaxThirst());
-        assertEquals(MAX_THIRST, drink2.getMaxThirst());
+        assertThat(drink1.getMaxThirst()).isEqualTo(MAX_THIRST);
+        assertThat(drink2.getMaxThirst()).isEqualTo(MAX_THIRST);
     }
 
     @Test
@@ -78,20 +75,20 @@ public class DrinkTest extends AbstractItemTest {
         final Drink clone = (Drink) drink1.clone();
 
         // Make sure all fields match
-        assertEquals(drink1.amount, clone.amount);
-        assertEquals(drink1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(drink1.amount);
+        assertThat(clone.properties).isEqualTo(drink1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(drink1, clone);
+        assertThat(clone).isNotSameAs(drink1);
 
         final Drink clone2 = (Drink) drink2.clone();
 
         // Make sure all fields match
-        assertEquals(drink2.amount, clone2.amount);
-        assertEquals(drink2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(drink2.amount);
+        assertThat(clone2.properties).isEqualTo(drink2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(drink2, clone2);
+        assertThat(clone2).isNotSameAs(drink2);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/EmptyBottleTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/EmptyBottleTest.java
@@ -3,11 +3,10 @@ package com.ao.model.worldobject;
 import com.ao.model.character.Character;
 import com.ao.model.inventory.Inventory;
 import com.ao.model.worldobject.properties.RefillableStatModifyingItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class EmptyBottleTest extends AbstractItemTest {
@@ -15,7 +14,7 @@ public class EmptyBottleTest extends AbstractItemTest {
     private EmptyBottle bottle1;
     private EmptyBottle bottle2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final RefillableStatModifyingItemProperties props1 = new RefillableStatModifyingItemProperties(WorldObjectType.EMPTY_BOTTLE, 1, "Empty Bottle", 1, 1, null, null, false, false, false, false, 0, 0, false, null);
         bottle1 = new EmptyBottle(props1, 1);
@@ -46,21 +45,21 @@ public class EmptyBottleTest extends AbstractItemTest {
         final EmptyBottle clone = (EmptyBottle) bottle1.clone();
 
         // Make sure all fields match
-        assertEquals(bottle1.amount, clone.amount);
-        assertEquals(bottle1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(bottle1.amount);
+        assertThat(clone.properties).isEqualTo(bottle1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(bottle1, clone);
+        assertThat(clone).isNotSameAs(bottle1);
 
 
         final EmptyBottle clone2 = (EmptyBottle) bottle2.clone();
 
         // Make sure all fields match
-        assertEquals(bottle2.amount, clone2.amount);
-        assertEquals(bottle2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(bottle2.amount);
+        assertThat(clone2.properties).isEqualTo(bottle2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(bottle2, clone2);
+        assertThat(clone2).isNotSameAs(bottle2);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/FilledBottleTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/FilledBottleTest.java
@@ -3,12 +3,11 @@ package com.ao.model.worldobject;
 import com.ao.model.character.Character;
 import com.ao.model.inventory.Inventory;
 import com.ao.model.worldobject.properties.RefillableStatModifyingItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class FilledBottleTest extends AbstractItemTest {
@@ -19,7 +18,7 @@ public class FilledBottleTest extends AbstractItemTest {
     private FilledBottle bottle2;
 
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final RefillableStatModifyingItemProperties emptyProps = new RefillableStatModifyingItemProperties(WorldObjectType.EMPTY_BOTTLE, 1, "Water Bottle", 1, 1, null, null, false, false, false, false, 0, 0, false, null);
         final RefillableStatModifyingItemProperties props = new RefillableStatModifyingItemProperties(WorldObjectType.FILLED_BOTTLE, 1, "Water Bottle", 1, 1, null, null, false, false, false, false, THIRST, THIRST, true, emptyProps);
@@ -43,14 +42,14 @@ public class FilledBottleTest extends AbstractItemTest {
 
         bottle2.use(character);
 
-        // Consumption of bottle2 requires these 2 calls.
+        // Consumption of bottle2 requires these 2 calls
         verify(inventory).cleanup();
         verify(character).addToThirstiness(THIRST);
 
-        assertThat(addedItem.getValue(), instanceOf(EmptyBottle.class));
+        assertThat(addedItem.getValue()).isInstanceOf(EmptyBottle.class);
         final EmptyBottle emptyBottle = (EmptyBottle) addedItem.getValue();
-        assertEquals(((RefillableStatModifyingItemProperties) bottle2.properties).getOtherStateProperties(), emptyBottle.properties);
-        assertEquals(1, emptyBottle.amount);
+        assertThat(emptyBottle.properties).isEqualTo(((RefillableStatModifyingItemProperties) bottle2.properties).getOtherStateProperties());
+        assertThat(emptyBottle.amount).isEqualTo(1);
     }
 
     @Test
@@ -63,13 +62,13 @@ public class FilledBottleTest extends AbstractItemTest {
 
         bottle1.use(character);
 
-        // Consumption of bottle1 requires just a call to addToThirstiness.
+        // Consumption of bottle1 requires just a call to addToThirstiness
         verify(character).addToThirstiness(THIRST);
 
-        assertThat(addedItem.getValue(), instanceOf(EmptyBottle.class));
+        assertThat(addedItem.getValue()).isInstanceOf(EmptyBottle.class);
         final EmptyBottle emptyBottle = (EmptyBottle) addedItem.getValue();
-        assertEquals(((RefillableStatModifyingItemProperties) bottle1.properties).getOtherStateProperties(), emptyBottle.properties);
-        assertEquals(1, emptyBottle.amount);
+        assertThat(emptyBottle.properties).isEqualTo(((RefillableStatModifyingItemProperties) bottle1.properties).getOtherStateProperties());
+        assertThat(emptyBottle.amount).isEqualTo(1);
     }
 
     @Test
@@ -77,27 +76,26 @@ public class FilledBottleTest extends AbstractItemTest {
         final FilledBottle clone = (FilledBottle) bottle1.clone();
 
         // Make sure all fields match
-        assertEquals(bottle1.amount, clone.amount);
-        assertEquals(bottle1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(bottle1.amount);
+        assertThat(clone.properties).isEqualTo(bottle1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(bottle1, clone);
-
+        assertThat(clone).isNotSameAs(bottle1);
 
         final FilledBottle clone2 = (FilledBottle) bottle2.clone();
 
         // Make sure all fields match
-        assertEquals(bottle2.amount, clone2.amount);
-        assertEquals(bottle2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(bottle2.amount);
+        assertThat(clone2.properties).isEqualTo(bottle2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(bottle2, clone2);
+        assertThat(clone2).isNotSameAs(bottle2);
     }
 
     @Test
     public void testGetThirst() {
-        assertEquals(THIRST, bottle1.getThirst());
-        assertEquals(THIRST, bottle2.getThirst());
+        assertThat(bottle1.getThirst()).isEqualTo(THIRST);
+        assertThat(bottle2.getThirst()).isEqualTo(THIRST);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/FoodTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/FoodTest.java
@@ -3,13 +3,11 @@ package com.ao.model.worldobject;
 import com.ao.model.character.Character;
 import com.ao.model.inventory.Inventory;
 import com.ao.model.worldobject.properties.StatModifyingItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class FoodTest extends AbstractItemTest {
@@ -20,7 +18,7 @@ public class FoodTest extends AbstractItemTest {
     private Food food1;
     private Food food2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final StatModifyingItemProperties props1 = new StatModifyingItemProperties(WorldObjectType.FOOD, 1, "Apple", 1, 1, null, null, false, false, false, false, MIN_HUN, MAX_HUN);
         food1 = new Food(props1, 5);
@@ -59,20 +57,19 @@ public class FoodTest extends AbstractItemTest {
         verify(character).addToHunger(capture.capture());
 
         /// Make sure the value is in the correct range
-        assertThat(capture.getValue(), greaterThanOrEqualTo(MIN_HUN));
-        assertThat(capture.getValue(), lessThanOrEqualTo(MAX_HUN));
+        assertThat(capture.getValue()).isBetween(MIN_HUN, MAX_HUN);
     }
 
     @Test
     public void testGetMinHun() {
-        assertEquals(MIN_HUN, food1.getMinHun());
-        assertEquals(MAX_HUN, food2.getMinHun());
+        assertThat(food1.getMinHun()).isEqualTo(MIN_HUN);
+        assertThat(food2.getMinHun()).isEqualTo(MAX_HUN);
     }
 
     @Test
     public void testGetMaxHun() {
-        assertEquals(MAX_HUN, food1.getMaxHun());
-        assertEquals(MAX_HUN, food2.getMaxHun());
+        assertThat(food1.getMaxHun()).isEqualTo(MAX_HUN);
+        assertThat(food2.getMaxHun()).isEqualTo(MAX_HUN);
     }
 
     @Test
@@ -80,21 +77,20 @@ public class FoodTest extends AbstractItemTest {
         final Food clone = (Food) food1.clone();
 
         // Make sure all fields match
-        assertEquals(food1.amount, clone.amount);
-        assertEquals(food1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(food1.amount);
+        assertThat(clone.properties).isEqualTo(food1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(food1, clone);
-
+        assertThat(clone).isNotSameAs(food1);
 
         final Food clone2 = (Food) food2.clone();
 
         // Make sure all fields match
-        assertEquals(food2.amount, clone2.amount);
-        assertEquals(food2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(food2.amount);
+        assertThat(clone2.properties).isEqualTo(food2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(food2, clone2);
+        assertThat(clone2).isNotSameAs(food2);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/GoldTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/GoldTest.java
@@ -3,11 +3,10 @@ package com.ao.model.worldobject;
 import com.ao.model.character.Character;
 import com.ao.model.inventory.Inventory;
 import com.ao.model.worldobject.properties.ItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class GoldTest extends AbstractItemTest {
@@ -15,7 +14,7 @@ public class GoldTest extends AbstractItemTest {
     private Gold gold1;
     private Gold gold2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final ItemProperties props = new ItemProperties(WorldObjectType.MONEY, 13, "Monedas de oro", 1, 1, null, null, false, true, true, true);
         gold1 = new Gold(props, 1000);
@@ -42,13 +41,13 @@ public class GoldTest extends AbstractItemTest {
     public void testClone() {
         final Gold clone = (Gold) gold1.clone();
 
-        assertEquals(gold1.getAmount(), clone.getAmount());
-        assertNotSame(clone, gold1);
+        assertThat(clone.getAmount()).isEqualTo(gold1.getAmount());
+        assertThat(clone).isNotSameAs(gold1);
 
         final Gold clone2 = (Gold) gold2.clone();
 
-        assertEquals(gold2.getAmount(), clone2.getAmount());
-        assertNotSame(clone2, gold2);
+        assertThat(clone2.getAmount()).isEqualTo(gold2.getAmount());
+        assertThat(clone2).isNotSameAs(gold2);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/GrabablePropTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/GrabablePropTest.java
@@ -2,11 +2,10 @@ package com.ao.model.worldobject;
 
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.properties.ItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -15,7 +14,7 @@ public class GrabablePropTest extends AbstractItemTest {
     private GrabableProp prop1;
     private GrabableProp prop2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final ItemProperties props1 = new ItemProperties(WorldObjectType.GRABABLE_PROP, 1, "Black Potion", 1, 1, null, null, false, true, false, true);
         prop1 = new GrabableProp(props1, 5);
@@ -44,20 +43,20 @@ public class GrabablePropTest extends AbstractItemTest {
         final GrabableProp clone = (GrabableProp) prop1.clone();
 
         // Make sure all fields match
-        assertEquals(prop1.amount, clone.amount);
-        assertEquals(prop1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(prop1.amount);
+        assertThat(clone.properties).isEqualTo(prop1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(prop1, clone);
-
+        assertThat(clone).isNotSameAs(prop1);
 
         final GrabableProp clone2 = (GrabableProp) prop2.clone();
 
         // Make sure all fields match
-        assertEquals(prop2.amount, clone2.amount);
-        assertEquals(prop2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(prop2.amount);
+        assertThat(clone2.properties).isEqualTo(prop2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(prop2, clone2);
+        assertThat(clone2).isNotSameAs(prop2);
     }
+
 }

--- a/server/src/test/java/com/ao/model/worldobject/HPPotionTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/HPPotionTest.java
@@ -3,13 +3,11 @@ package com.ao.model.worldobject;
 import com.ao.model.character.Character;
 import com.ao.model.inventory.Inventory;
 import com.ao.model.worldobject.properties.StatModifyingItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class HPPotionTest extends AbstractItemTest {
@@ -20,7 +18,7 @@ public class HPPotionTest extends AbstractItemTest {
     private HPPotion potion1;
     private HPPotion potion2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final StatModifyingItemProperties props1 = new StatModifyingItemProperties(WorldObjectType.HP_POTION, 1, "Red Potion", 1, 1, null, null, false, false, false, false, MIN_HP, MAX_HP);
         potion1 = new HPPotion(props1, 5);
@@ -58,20 +56,19 @@ public class HPPotionTest extends AbstractItemTest {
         final ArgumentCaptor<Integer> capture = ArgumentCaptor.forClass(Integer.class);
         verify(character).addToHitPoints(capture.capture());
         /// Make sure the value is in the correct range
-        assertThat(capture.getValue(), greaterThanOrEqualTo(MIN_HP));
-        assertThat(capture.getValue(), lessThanOrEqualTo(MAX_HP));
+        assertThat(capture.getValue()).isBetween(MIN_HP, MAX_HP);
     }
 
     @Test
     public void testGetMinHP() {
-        assertEquals(MIN_HP, potion1.getMinHP());
-        assertEquals(MAX_HP, potion2.getMinHP());
+        assertThat(potion1.getMinHP()).isEqualTo(MIN_HP);
+        assertThat(potion2.getMinHP()).isEqualTo(MAX_HP);
     }
 
     @Test
     public void testGetMaxHP() {
-        assertEquals(MAX_HP, potion1.getMaxHP());
-        assertEquals(MAX_HP, potion2.getMaxHP());
+        assertThat(potion1.getMaxHP()).isEqualTo(MAX_HP);
+        assertThat(potion2.getMaxHP()).isEqualTo(MAX_HP);
     }
 
     @Test
@@ -79,21 +76,20 @@ public class HPPotionTest extends AbstractItemTest {
         final HPPotion clone = (HPPotion) potion1.clone();
 
         // Make sure all fields match
-        assertEquals(potion1.amount, clone.amount);
-        assertEquals(potion1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(potion1.amount);
+        assertThat(clone.properties).isEqualTo(potion1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(potion1, clone);
-
+        assertThat(clone).isNotSameAs(potion1);
 
         final HPPotion clone2 = (HPPotion) potion2.clone();
 
         // Make sure all fields match
-        assertEquals(potion2.amount, clone2.amount);
-        assertEquals(potion2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(potion2.amount);
+        assertThat(clone2.properties).isEqualTo(potion2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(potion2, clone2);
+        assertThat(clone2).isNotSameAs(potion2);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/HelmetTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/HelmetTest.java
@@ -2,11 +2,10 @@ package com.ao.model.worldobject;
 
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.properties.DefensiveItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -21,7 +20,7 @@ public class HelmetTest extends AbstractDefensiveItemTest {
     private Helmet helmet1;
     private Helmet helmet2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final DefensiveItemProperties props1 = new DefensiveItemProperties(WorldObjectType.HELMET, 1, "Viking Helmet", 1, 1, 0, null, null, false, false, false, false, 1, MIN_DEF, MAX_DEF, MIN_MAGIC_DEF, MAX_MAGIC_DEF);
         helmet1 = new Helmet(props1, 5);
@@ -40,21 +39,21 @@ public class HelmetTest extends AbstractDefensiveItemTest {
         final Helmet clone = (Helmet) helmet1.clone();
 
         // Make sure all fields match
-        assertEquals(helmet1.amount, clone.amount);
-        assertEquals(helmet1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(helmet1.amount);
+        assertThat(clone.properties).isEqualTo(helmet1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(helmet1, clone);
+        assertThat(clone).isNotSameAs(helmet1);
 
 
         final Helmet clone2 = (Helmet) helmet2.clone();
 
         // Make sure all fields match
-        assertEquals(helmet2.amount, clone2.amount);
-        assertEquals(helmet2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(helmet2.amount);
+        assertThat(clone2.properties).isEqualTo(helmet2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(helmet2, clone2);
+        assertThat(clone2).isNotSameAs(helmet2);
     }
 
     @Test

--- a/server/src/test/java/com/ao/model/worldobject/KeyTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/KeyTest.java
@@ -1,11 +1,10 @@
 package com.ao.model.worldobject;
 
 import com.ao.model.worldobject.properties.KeyProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KeyTest extends AbstractWorldObjectTest {
 
@@ -13,7 +12,7 @@ public class KeyTest extends AbstractWorldObjectTest {
 
     private Key key1;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final KeyProperties props1 = new KeyProperties(WorldObjectType.KEY, 1, "Llave maestra", 1, 1, 0, null, null, false, false, false, false, CODE);
         key1 = new Key(props1, 1);
@@ -27,17 +26,17 @@ public class KeyTest extends AbstractWorldObjectTest {
         final Key clone = (Key) key1.clone();
 
         // Make sure all fields match
-        assertEquals(key1.amount, clone.amount);
-        assertEquals(key1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(key1.amount);
+        assertThat(clone.properties).isEqualTo(key1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(key1, clone);
+        assertThat(clone).isNotSameAs(key1);
 
     }
 
     @Test
     public void testGetMinHit() {
-        assertEquals(CODE, key1.getCode());
+        assertThat(key1.getCode()).isEqualTo(CODE);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/ManaPotionTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/ManaPotionTest.java
@@ -3,13 +3,11 @@ package com.ao.model.worldobject;
 import com.ao.model.character.Character;
 import com.ao.model.inventory.Inventory;
 import com.ao.model.worldobject.properties.StatModifyingItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class ManaPotionTest extends AbstractItemTest {
@@ -20,7 +18,7 @@ public class ManaPotionTest extends AbstractItemTest {
     private ManaPotion potion1;
     private ManaPotion potion2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final StatModifyingItemProperties props1 = new StatModifyingItemProperties(WorldObjectType.MANA_POTION, 1, "Blue Potion", 1, 1, null, null, false, false, false, false, MIN_MANA, MAX_MANA);
         potion1 = new ManaPotion(props1, 5);
@@ -59,20 +57,19 @@ public class ManaPotionTest extends AbstractItemTest {
         verify(character).addToMana(capture.capture());
 
         /// Make sure the value is in the correct range
-        assertThat(capture.getValue(), greaterThanOrEqualTo(MIN_MANA));
-        assertThat(capture.getValue(), lessThanOrEqualTo(MAX_MANA));
+        assertThat(capture.getValue()).isBetween(MIN_MANA, MAX_MANA);
     }
 
     @Test
     public void testGetMinMana() {
-        assertEquals(MIN_MANA, potion1.getMinMana());
-        assertEquals(MAX_MANA, potion2.getMinMana());
+        assertThat(potion1.getMinMana()).isEqualTo(MIN_MANA);
+        assertThat(potion2.getMinMana()).isEqualTo(MAX_MANA);
     }
 
     @Test
     public void testGetMaxMana() {
-        assertEquals(MAX_MANA, potion1.getMaxMana());
-        assertEquals(MAX_MANA, potion2.getMaxMana());
+        assertThat(potion1.getMaxMana()).isEqualTo(MAX_MANA);
+        assertThat(potion2.getMaxMana()).isEqualTo(MAX_MANA);
     }
 
     @Test
@@ -80,21 +77,20 @@ public class ManaPotionTest extends AbstractItemTest {
         final ManaPotion clone = (ManaPotion) potion1.clone();
 
         // Make sure all fields match
-        assertEquals(potion1.amount, clone.amount);
-        assertEquals(potion1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(potion1.amount);
+        assertThat(clone.properties).isEqualTo(potion1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(potion1, clone);
-
+        assertThat(clone).isNotSameAs(potion1);
 
         final ManaPotion clone2 = (ManaPotion) potion2.clone();
 
         // Make sure all fields match
-        assertEquals(potion2.amount, clone2.amount);
-        assertEquals(potion2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(potion2.amount);
+        assertThat(clone2.properties).isEqualTo(potion2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(potion2, clone2);
+        assertThat(clone2).isNotSameAs(potion2);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/MineTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/MineTest.java
@@ -1,20 +1,17 @@
 package com.ao.model.worldobject;
 
 import com.ao.model.worldobject.properties.ResourceSourceProperties;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public class MineTest extends AbstractResourceSourceTest {
 
     private static final ResourceSourceType resourceSourceType = ResourceSourceType.MINE;
 
-    private Mine mine1;
-
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final ResourceSourceProperties props1 = new ResourceSourceProperties(WorldObjectType.MINE, 1, "Cooper mine", 1, 6, resourceSourceType);
-        mine1 = new Mine(props1);
-
-        object = mine1;
+        object = new Mine(props1);
         objectProps = props1;
     }
+
 }

--- a/server/src/test/java/com/ao/model/worldobject/MineralTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/MineralTest.java
@@ -3,11 +3,10 @@ package com.ao.model.worldobject;
 import com.ao.model.character.Character;
 import com.ao.model.inventory.Inventory;
 import com.ao.model.worldobject.properties.ItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class MineralTest extends AbstractItemTest {
@@ -15,7 +14,7 @@ public class MineralTest extends AbstractItemTest {
     private Mineral mineral1;
     private Mineral mineral2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final ItemProperties props1 = new ItemProperties(WorldObjectType.MINERAL, 1, "Gold", 1, 1, null, null, false, false, false, false);
         mineral1 = new Mineral(props1, 1);
@@ -46,21 +45,20 @@ public class MineralTest extends AbstractItemTest {
         final Mineral clone = (Mineral) mineral1.clone();
 
         // Make sure all fields match
-        assertEquals(mineral1.amount, clone.amount);
-        assertEquals(mineral1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(mineral1.amount);
+        assertThat(clone.properties).isEqualTo(mineral1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(mineral1, clone);
-
+        assertThat(clone).isNotSameAs(mineral1);
 
         final Mineral clone2 = (Mineral) mineral2.clone();
 
         // Make sure all fields match
-        assertEquals(mineral2.amount, clone2.amount);
-        assertEquals(mineral2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(mineral2.amount);
+        assertThat(clone2.properties).isEqualTo(mineral2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(mineral2, clone2);
+        assertThat(clone2).isNotSameAs(mineral2);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/MusicalInstrumentTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/MusicalInstrumentTest.java
@@ -2,13 +2,13 @@ package com.ao.model.worldobject;
 
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.properties.MusicalInstrumentProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -22,7 +22,7 @@ public class MusicalInstrumentTest extends AbstractItemTest {
     private List<Integer> sounds1;
     private List<Integer> sounds2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         sounds1 = new LinkedList<>();
         sounds1.add(1);
@@ -47,21 +47,20 @@ public class MusicalInstrumentTest extends AbstractItemTest {
         final MusicalInstrument clone = (MusicalInstrument) instrument1.clone();
 
         // Make sure all fields match
-        assertEquals(instrument1.amount, clone.amount);
-        assertEquals(instrument1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(instrument1.amount);
+        assertThat(clone.properties).isEqualTo(instrument1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(instrument1, clone);
-
+        assertThat(clone).isNotSameAs(instrument1);
 
         final MusicalInstrument clone2 = (MusicalInstrument) instrument2.clone();
 
         // Make sure all fields match
-        assertEquals(instrument2.amount, clone2.amount);
-        assertEquals(instrument2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(instrument2.amount);
+        assertThat(clone2.properties).isEqualTo(instrument2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(instrument2, clone2);
+        assertThat(clone2).isNotSameAs(instrument2);
     }
 
     @Test
@@ -78,8 +77,8 @@ public class MusicalInstrumentTest extends AbstractItemTest {
     @Test
     public void testGetSounds() {
         for (int i = 0; i < ATTEMPTS; i++)
-            assertTrue(sounds1.contains(instrument1.getSoundToPlay()));
-        assertEquals(sounds2.get(0), (Integer) instrument2.getSoundToPlay());
+            assertThat(instrument1.getSoundToPlay()).isIn(sounds1);
+        assertThat(instrument2.getSoundToPlay()).isEqualTo(sounds2.get(0));
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/ParchmentTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/ParchmentTest.java
@@ -5,11 +5,10 @@ import com.ao.model.inventory.Inventory;
 import com.ao.model.spell.Spell;
 import com.ao.model.spell.effect.Effect;
 import com.ao.model.worldobject.properties.ParchmentProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class ParchmentTest extends AbstractItemTest {
@@ -19,7 +18,7 @@ public class ParchmentTest extends AbstractItemTest {
     private Spell spell1;
     private Spell spell2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         spell1 = new Spell(1, new Effect[]{}, 0, 0, 0, "foo", "foo", false, 1, 2, "OHL VOR PEK");
         final ParchmentProperties props1 = new ParchmentProperties(WorldObjectType.PARCHMENT, 1, "Dardo Mágico", 1, 300, null, null, false, false, false, false, spell1);
@@ -36,8 +35,8 @@ public class ParchmentTest extends AbstractItemTest {
 
     @Test
     public void testGetSpell() {
-        assertEquals(parchment1.getSpell(), spell1);
-        assertEquals(parchment2.getSpell(), spell2);
+        assertThat(spell1).isEqualTo(parchment1.getSpell());
+        assertThat(spell2).isEqualTo(parchment2.getSpell());
     }
 
     @Test
@@ -50,7 +49,7 @@ public class ParchmentTest extends AbstractItemTest {
 
         parchment1.use(character);
 
-        // Consumption of parchment1 requires these 2 calls.
+        // Consumption of parchment1 requires these 2 calls
         verify(inventory).cleanup();
         verify(character).addSpell(spell1);
     }
@@ -65,7 +64,7 @@ public class ParchmentTest extends AbstractItemTest {
 
         parchment2.use(character);
 
-        // Consumption of parchment1 requires just a call to addSpell.
+        // Consumption of parchment1 requires just a call to addSpell
         verify(character).addSpell(spell2);
     }
 
@@ -79,7 +78,7 @@ public class ParchmentTest extends AbstractItemTest {
 
         parchment1.use(character);
 
-        // Consumption of parchment1 already learnt doesn't requires any call.
+        // Consumption of parchment1 already learnt doesn't require any call
         verify(character).getSpells();
         verifyNoMoreInteractions(character, inventory);
     }
@@ -88,17 +87,17 @@ public class ParchmentTest extends AbstractItemTest {
     public void testClone() {
         final Parchment clone1 = (Parchment) parchment1.clone();
 
-        assertEquals(clone1.getAmount(), parchment1.getAmount());
-        assertEquals(clone1.getSpell(), parchment1.getSpell());
-        assertEquals(clone1.properties, parchment1.properties);
-        assertNotSame(clone1, parchment1);
+        assertThat(parchment1.getAmount()).isEqualTo(clone1.getAmount());
+        assertThat(parchment1.getSpell()).isEqualTo(clone1.getSpell());
+        assertThat(parchment1.properties).isEqualTo(clone1.properties);
+        assertThat(parchment1).isNotSameAs(clone1);
 
         final Parchment clone2 = (Parchment) parchment2.clone();
 
-        assertEquals(clone2.getAmount(), parchment2.getAmount());
-        assertEquals(clone2.getSpell(), parchment2.getSpell());
-        assertEquals(clone2.properties, parchment2.properties);
-        assertNotSame(clone2, parchment2);
+        assertThat(parchment2.getAmount()).isEqualTo(clone2.getAmount());
+        assertThat(parchment2.getSpell()).isEqualTo(clone2.getSpell());
+        assertThat(parchment2.properties).isEqualTo(clone2.properties);
+        assertThat(parchment2).isNotSameAs(clone2);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/PoisonPotionTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/PoisonPotionTest.java
@@ -3,11 +3,10 @@ package com.ao.model.worldobject;
 import com.ao.model.character.Character;
 import com.ao.model.inventory.Inventory;
 import com.ao.model.worldobject.properties.ItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class PoisonPotionTest extends AbstractItemTest {
@@ -15,7 +14,7 @@ public class PoisonPotionTest extends AbstractItemTest {
     private PoisonPotion potion1;
     private PoisonPotion potion2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final ItemProperties props1 = new ItemProperties(WorldObjectType.POISON_POTION, 1, "Violet Potion", 1, 1, null, null, false, false, false, false);
         potion1 = new PoisonPotion(props1, 5);
@@ -58,21 +57,21 @@ public class PoisonPotionTest extends AbstractItemTest {
         final PoisonPotion clone = (PoisonPotion) potion1.clone();
 
         // Make sure all fields match
-        assertEquals(potion1.amount, clone.amount);
-        assertEquals(potion1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(potion1.amount);
+        assertThat(clone.properties).isEqualTo(potion1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(potion1, clone);
+        assertThat(clone).isNotSameAs(potion1);
 
 
         final PoisonPotion clone2 = (PoisonPotion) potion2.clone();
 
         // Make sure all fields match
-        assertEquals(potion2.amount, clone2.amount);
-        assertEquals(potion2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(potion2.amount);
+        assertThat(clone2.properties).isEqualTo(potion2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(potion2, clone2);
+        assertThat(clone2).isNotSameAs(potion2);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/PropTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/PropTest.java
@@ -1,20 +1,16 @@
 package com.ao.model.worldobject;
 
 import com.ao.model.worldobject.properties.TeleportProperties;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public class PropTest extends AbstractWorldObjectTest {
 
     private static final int RADIUS = 4;
 
-    private Prop prop1;
-
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final TeleportProperties props1 = new TeleportProperties(WorldObjectType.PROP, 1, "Teleport", 1, RADIUS);
-        prop1 = new Prop(props1);
-
-        object = prop1;
+        object = new Prop(props1);
         objectProps = props1;
     }
 

--- a/server/src/test/java/com/ao/model/worldobject/RangedWeaponTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/RangedWeaponTest.java
@@ -2,12 +2,10 @@ package com.ao.model.worldobject;
 
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.properties.RangedWeaponProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -20,7 +18,7 @@ public class RangedWeaponTest extends AbstractEquipableItemTest {
     protected RangedWeapon weapon1;
     protected RangedWeapon weapon2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final RangedWeaponProperties props1 = new RangedWeaponProperties(WorldObjectType.WEAPON, 1, "Throw Knifes", 1, 1, 0, null, null, false, false, false, false, 1, true, PIERCING_DAMAGE, MIN_HIT, MAX_HIT, false);
         weapon1 = new RangedWeapon(props1, 5);
@@ -39,21 +37,20 @@ public class RangedWeaponTest extends AbstractEquipableItemTest {
         final RangedWeapon clone = (RangedWeapon) weapon1.clone();
 
         // Make sure all fields match
-        assertEquals(weapon1.amount, clone.amount);
-        assertEquals(weapon1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(weapon1.amount);
+        assertThat(clone.properties).isEqualTo(weapon1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(weapon1, clone);
-
+        assertThat(clone).isNotSameAs(weapon1);
 
         final RangedWeapon clone2 = (RangedWeapon) weapon2.clone();
 
         // Make sure all fields match
-        assertEquals(weapon2.amount, clone2.amount);
-        assertEquals(weapon2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(weapon2.amount);
+        assertThat(clone2.properties).isEqualTo(weapon2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(weapon2, clone2);
+        assertThat(clone2).isNotSameAs(weapon2);
     }
 
     @Test
@@ -69,41 +66,40 @@ public class RangedWeaponTest extends AbstractEquipableItemTest {
 
     @Test
     public void testGetMinHit() {
-        assertEquals(MIN_HIT, weapon1.getMinHit());
-        assertEquals(MAX_HIT, weapon2.getMinHit());
+        assertThat(weapon1.getMinHit()).isEqualTo(MIN_HIT);
+        assertThat(weapon2.getMinHit()).isEqualTo(MAX_HIT);
     }
 
     @Test
     public void testGetMaxHit() {
-        assertEquals(MAX_HIT, weapon1.getMaxHit());
-        assertEquals(MAX_HIT, weapon2.getMaxHit());
+        assertThat(weapon1.getMaxHit()).isEqualTo(MAX_HIT);
+        assertThat(weapon2.getMaxHit()).isEqualTo(MAX_HIT);
     }
 
     @Test
     public void testGetPiercingDamage() {
-        assertEquals(PIERCING_DAMAGE, weapon1.getPiercingDamage());
-        assertEquals(PIERCING_DAMAGE, weapon2.getPiercingDamage());
+        assertThat(weapon1.getPiercingDamage()).isEqualTo(PIERCING_DAMAGE);
+        assertThat(weapon2.getPiercingDamage()).isEqualTo(PIERCING_DAMAGE);
     }
 
     @Test
     public void testGetStabs() {
-        assertTrue(weapon1.getStabs());
-        assertFalse(weapon2.getStabs());
+        assertThat(weapon1.getStabs()).isTrue();
+        assertThat(weapon2.getStabs()).isFalse();
     }
 
     @Test
     public void testGetDamage() {
         final int damage = weapon1.getDamage();
 
-        assertThat(damage, greaterThanOrEqualTo(MIN_HIT));
-        assertThat(damage, lessThanOrEqualTo(MAX_HIT));
-        assertEquals(MAX_HIT, weapon2.getDamage());
+        assertThat(damage).isBetween(MIN_HIT, MAX_HIT);
+        assertThat(weapon2.getDamage()).isEqualTo(MAX_HIT);
     }
 
     @Test
     public void testGetNeedsAmmunition() {
-        assertFalse(weapon1.getNeedsAmmunition());
-        assertTrue(weapon2.getNeedsAmmunition());
+        assertThat(weapon1.getNeedsAmmunition()).isFalse();
+        assertThat(weapon2.getNeedsAmmunition()).isTrue();
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/ShieldTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/ShieldTest.java
@@ -2,11 +2,10 @@ package com.ao.model.worldobject;
 
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.properties.DefensiveItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -21,7 +20,7 @@ public class ShieldTest extends AbstractDefensiveItemTest {
     private Shield shield1;
     private Shield shield2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final DefensiveItemProperties props1 = new DefensiveItemProperties(WorldObjectType.SHIELD, 1, "Turtle Shield", 1, 1, 0, null, null, false, false, false, false, 1, MIN_DEF, MAX_DEF, MIN_MAGIC_DEF, MAX_MAGIC_DEF);
         shield1 = new Shield(props1, 5);
@@ -40,21 +39,20 @@ public class ShieldTest extends AbstractDefensiveItemTest {
         final Shield clone = (Shield) shield1.clone();
 
         // Make sure all fields match
-        assertEquals(shield1.amount, clone.amount);
-        assertEquals(shield1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(shield1.amount);
+        assertThat(clone.properties).isEqualTo(shield1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(shield1, clone);
-
+        assertThat(clone).isNotSameAs(shield1);
 
         final Shield clone2 = (Shield) shield2.clone();
 
         // Make sure all fields match
-        assertEquals(shield2.amount, clone2.amount);
-        assertEquals(shield2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(shield2.amount);
+        assertThat(clone2.properties).isEqualTo(shield2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(shield2, clone);
+        assertThat(clone2).isNotSameAs(shield2);
     }
 
     @Test

--- a/server/src/test/java/com/ao/model/worldobject/StaffTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/StaffTest.java
@@ -1,10 +1,10 @@
 package com.ao.model.worldobject;
 
 import com.ao.model.worldobject.properties.StaffProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StaffTest extends WeaponTest {
 
@@ -15,7 +15,7 @@ public class StaffTest extends WeaponTest {
     private static final int DAMAGE_BONUS = 20;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final StaffProperties props1 = new StaffProperties(WorldObjectType.WEAPON, 1, "Walnut Rod", 1, 1, 0, null, null, false, false, false, false, 1, true, PIERCING_DAMAGE, MIN_HIT, MAX_HIT, MAGIC_POWER, DAMAGE_BONUS);
         weapon1 = new Staff(props1, 5);
@@ -31,14 +31,14 @@ public class StaffTest extends WeaponTest {
 
     @Test
     public void testGetDamageBonus() {
-        assertEquals(DAMAGE_BONUS, ((Staff) weapon1).getDamageBonus());
-        assertEquals(DAMAGE_BONUS, ((Staff) weapon2).getDamageBonus());
+        assertThat(((Staff) weapon1).getDamageBonus()).isEqualTo(DAMAGE_BONUS);
+        assertThat(((Staff) weapon2).getDamageBonus()).isEqualTo(DAMAGE_BONUS);
     }
 
     @Test
     public void testGetMagicPower() {
-        assertEquals(MAGIC_POWER, ((Staff) weapon1).getMagicPower());
-        assertEquals(MAGIC_POWER, ((Staff) weapon2).getMagicPower());
+        assertThat(((Staff) weapon1).getMagicPower()).isEqualTo(MAGIC_POWER);
+        assertThat(((Staff) weapon2).getMagicPower()).isEqualTo(MAGIC_POWER);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/StrengthPotionTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/StrengthPotionTest.java
@@ -3,13 +3,11 @@ package com.ao.model.worldobject;
 import com.ao.model.character.Character;
 import com.ao.model.inventory.Inventory;
 import com.ao.model.worldobject.properties.TemporalStatModifyingItemProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -22,7 +20,7 @@ public class StrengthPotionTest extends AbstractItemTest {
     private StrengthPotion potion1;
     private StrengthPotion potion2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final TemporalStatModifyingItemProperties props1 = new TemporalStatModifyingItemProperties(WorldObjectType.STRENGTH_POTION, 1, "Green Potion", 1, 1, null, null, false, false, false, false, MIN_STR, MAX_STR, DURATION);
         potion1 = new StrengthPotion(props1, 5);
@@ -61,20 +59,19 @@ public class StrengthPotionTest extends AbstractItemTest {
         verify(character).addToStrength(capture.capture(), eq(DURATION));
 
         /// Make sure the value is in the correct range
-        assertThat(capture.getValue(), greaterThanOrEqualTo(MIN_STR));
-        assertThat(capture.getValue(), lessThanOrEqualTo(MAX_STR));
+        assertThat(capture.getValue()).isBetween(MIN_STR, MAX_STR);
     }
 
     @Test
     public void testGetMinModifier() {
-        assertEquals(MIN_STR, potion1.getMinModifier());
-        assertEquals(MAX_STR, potion2.getMinModifier());
+        assertThat(potion1.getMinModifier()).isEqualTo(MIN_STR);
+        assertThat(potion2.getMinModifier()).isEqualTo(MAX_STR);
     }
 
     @Test
     public void testGetMaxModifier() {
-        assertEquals(MAX_STR, potion1.getMaxModifier());
-        assertEquals(MAX_STR, potion2.getMaxModifier());
+        assertThat(potion1.getMaxModifier()).isEqualTo(MAX_STR);
+        assertThat(potion2.getMaxModifier()).isEqualTo(MAX_STR);
     }
 
     @Test
@@ -82,26 +79,26 @@ public class StrengthPotionTest extends AbstractItemTest {
         final StrengthPotion clone = (StrengthPotion) potion1.clone();
 
         // Make sure all fields match
-        assertEquals(potion1.amount, clone.amount);
-        assertEquals(potion1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(potion1.amount);
+        assertThat(clone.properties).isEqualTo(potion1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(potion1, clone);
-
+        assertThat(clone).isNotSameAs(potion1);
 
         final StrengthPotion clone2 = (StrengthPotion) potion2.clone();
 
         // Make sure all fields match
-        assertEquals(potion2.amount, clone2.amount);
-        assertEquals(potion2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(potion2.amount);
+        assertThat(clone2.properties).isEqualTo(potion2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(potion2, clone2);
+        assertThat(clone2).isNotSameAs(potion2);
     }
 
     @Test
     public void testGetEffectDuration() {
-        assertEquals(DURATION, potion1.getEffectDuration());
-        assertEquals(DURATION, potion2.getEffectDuration());
+        assertThat(potion1.getEffectDuration()).isEqualTo(DURATION);
+        assertThat(potion2.getEffectDuration()).isEqualTo(DURATION);
     }
+
 }

--- a/server/src/test/java/com/ao/model/worldobject/TeleportTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/TeleportTest.java
@@ -1,10 +1,10 @@
 package com.ao.model.worldobject;
 
 import com.ao.model.worldobject.properties.TeleportProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TeleportTest extends AbstractWorldObjectTest {
 
@@ -12,7 +12,7 @@ public class TeleportTest extends AbstractWorldObjectTest {
 
     private Teleport teleport1;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final TeleportProperties props1 = new TeleportProperties(WorldObjectType.TELEPORT, 1, "Teleport", 1, RADIUS);
         teleport1 = new Teleport(props1);
@@ -23,7 +23,7 @@ public class TeleportTest extends AbstractWorldObjectTest {
 
     @Test
     public void testGetRadius() {
-        assertEquals(RADIUS, teleport1.getRadius());
+        assertThat(teleport1.getRadius()).isEqualTo(RADIUS);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/TreeTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/TreeTest.java
@@ -1,20 +1,16 @@
 package com.ao.model.worldobject;
 
 import com.ao.model.worldobject.properties.ResourceSourceProperties;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public class TreeTest extends AbstractResourceSourceTest {
 
     private static final ResourceSourceType resourceSourceType = ResourceSourceType.TREE;
 
-    private Tree tree1;
-
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ResourceSourceProperties props1 = new ResourceSourceProperties(WorldObjectType.TREE, 1, "Elven Tree", 1, 5, resourceSourceType);
-        tree1 = new Tree(props1);
-
-        object = tree1;
+        object = new Tree(props1);
         objectProps = props1;
     }
 

--- a/server/src/test/java/com/ao/model/worldobject/WeaponTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/WeaponTest.java
@@ -2,10 +2,10 @@ package com.ao.model.worldobject;
 
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.properties.WeaponProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -18,7 +18,7 @@ public class WeaponTest extends AbstractEquipableItemTest {
     protected Weapon weapon1;
     protected Weapon weapon2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final WeaponProperties props1 = new WeaponProperties(WorldObjectType.WEAPON, 1, "Bastard Sword", 1, 1, 0, null, null, false, false, false, false, 1, true, PIERCING_DAMAGE, MIN_HIT, MAX_HIT);
         weapon1 = new Weapon(props1, 5);
@@ -37,27 +37,27 @@ public class WeaponTest extends AbstractEquipableItemTest {
         final Weapon clone = (Weapon) weapon1.clone();
 
         // Make sure all fields match
-        assertEquals(weapon1.amount, clone.amount);
-        assertEquals(weapon1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(weapon1.amount);
+        assertThat(clone.properties).isEqualTo(weapon1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(weapon1, clone);
+        assertThat(clone).isNotSameAs(weapon1);
 
         final Weapon clone2 = (Weapon) weapon2.clone();
 
         // Make sure all fields match
-        assertEquals(weapon2.amount, clone2.amount);
-        assertEquals(weapon2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(weapon2.amount);
+        assertThat(clone2.properties).isEqualTo(weapon2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(weapon2, clone2);
+        assertThat(clone2).isNotSameAs(weapon2);
     }
 
     @Test
     public void testUse() {
         final Character character = mock(Character.class);
 
-        // nothing should happen
+        // Nothing should happen
         weapon1.use(character);
         weapon2.use(character);
 
@@ -66,35 +66,33 @@ public class WeaponTest extends AbstractEquipableItemTest {
 
     @Test
     public void testGetMinHit() {
-        assertEquals(MIN_HIT, weapon1.getMinHit());
-        assertEquals(MAX_HIT, weapon2.getMinHit());
+        assertThat(weapon1.getMinHit()).isEqualTo(MIN_HIT);
+        assertThat(weapon2.getMinHit()).isEqualTo(MAX_HIT);
     }
 
     @Test
     public void testGetMaxHit() {
-        assertEquals(MAX_HIT, weapon1.getMaxHit());
-        assertEquals(MAX_HIT, weapon2.getMaxHit());
+        assertThat(weapon1.getMaxHit()).isEqualTo(MAX_HIT);
+        assertThat(weapon2.getMaxHit()).isEqualTo(MAX_HIT);
     }
 
     @Test
     public void testGetPiercingDamage() {
-        assertEquals(PIERCING_DAMAGE, weapon1.getPiercingDamage());
-        assertEquals(PIERCING_DAMAGE, weapon2.getPiercingDamage());
+        assertThat(weapon1.getPiercingDamage()).isEqualTo(PIERCING_DAMAGE);
+        assertThat(weapon2.getPiercingDamage()).isEqualTo(PIERCING_DAMAGE);
     }
 
     @Test
     public void testGetStabs() {
-        assertTrue(weapon1.getStabs());
-        assertFalse(weapon2.getStabs());
+        assertThat(weapon1.getStabs()).isTrue();
+        assertThat(weapon2.getStabs()).isFalse();
     }
 
     @Test
     public void testGetDamage() {
         final int damage = weapon1.getDamage();
-
-        assertTrue(damage >= MIN_HIT);
-        assertTrue(damage <= MAX_HIT);
-        assertEquals(MAX_HIT, weapon2.getDamage());
+        assertThat(damage).isBetween(MIN_HIT, MAX_HIT);
+        assertThat(weapon2.getDamage()).isEqualTo(MAX_HIT);
     }
 
 }

--- a/server/src/test/java/com/ao/model/worldobject/WoodTest.java
+++ b/server/src/test/java/com/ao/model/worldobject/WoodTest.java
@@ -2,11 +2,10 @@ package com.ao.model.worldobject;
 
 import com.ao.model.character.Character;
 import com.ao.model.worldobject.properties.WoodProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -15,7 +14,7 @@ public class WoodTest extends AbstractItemTest {
     private Wood wood1;
     private Wood wood2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final WoodProperties props1 = new WoodProperties(WorldObjectType.WOOD, 1, "Black Potion", 1, 1, null, null, false, false, false, false, WoodType.NORMAL);
         wood1 = new Wood(props1, 5);
@@ -32,7 +31,7 @@ public class WoodTest extends AbstractItemTest {
     public void testUse() {
         final Character character = mock(Character.class);
 
-        // nothing should happen
+        // Nothing should happen
         wood1.use(character);
         wood2.use(character);
 
@@ -44,27 +43,26 @@ public class WoodTest extends AbstractItemTest {
         final Wood clone = (Wood) wood1.clone();
 
         // Make sure all fields match
-        assertEquals(wood1.amount, clone.amount);
-        assertEquals(wood1.properties, clone.properties);
+        assertThat(clone.amount).isEqualTo(wood1.amount);
+        assertThat(clone.properties).isEqualTo(wood1.properties);
 
         // Make sure the object itself is different
-        assertNotSame(wood1, clone);
-
+        assertThat(clone).isNotSameAs(wood1);
 
         final Wood clone2 = (Wood) wood2.clone();
 
         // Make sure all fields match
-        assertEquals(wood2.amount, clone2.amount);
-        assertEquals(wood2.properties, clone2.properties);
+        assertThat(clone2.amount).isEqualTo(wood2.amount);
+        assertThat(clone2.properties).isEqualTo(wood2.properties);
 
         // Make sure the object itself is different
-        assertNotSame(wood2, clone2);
+        assertThat(clone2).isNotSameAs(wood2);
     }
 
     @Test
     public void testGetWoodType() {
-        assertEquals(WoodType.NORMAL, wood1.getWoodType());
-        assertEquals(WoodType.ELVEN, wood2.getWoodType());
+        assertThat(wood1.getWoodType()).isEqualTo(WoodType.NORMAL);
+        assertThat(wood2.getWoodType()).isEqualTo(WoodType.ELVEN);
     }
 
 }

--- a/server/src/test/java/com/ao/network/packet/incoming/LoginNewCharacterPacketTest.java
+++ b/server/src/test/java/com/ao/network/packet/incoming/LoginNewCharacterPacketTest.java
@@ -20,13 +20,12 @@ import com.ao.security.SecurityManager;
 import com.ao.service.LoginService;
 import com.ao.service.MapService;
 import com.ao.service.login.LoginServiceImpl;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class LoginNewCharacterPacketTest {
@@ -59,7 +58,7 @@ public class LoginNewCharacterPacketTest {
     private SecurityManager security;
     private MapService mapService;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         packet = new LoginNewCharacterPacket();
         errPacket = ArgumentCaptor.forClass(ErrorMessagePacket.class);
@@ -77,7 +76,7 @@ public class LoginNewCharacterPacketTest {
         config.setCharacterCreationEnabled(true);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         ApplicationContext.getInstance(AccountDAO.class).delete(CHARACTER_NAME);
         ApplicationContext.getInstance(AccountDAO.class).delete(INVALID_CHARACTER_NAME);
@@ -91,19 +90,18 @@ public class LoginNewCharacterPacketTest {
 
         packet.handle(inputBuffer, connection);
         verify(connection).send(errPacket.capture());
-        assertEquals(UserCharacterBuilder.INVALID_EMAIL_ERROR, errPacket.getValue().getMessage());
+        assertThat(errPacket.getValue().getMessage()).isEqualTo(UserCharacterBuilder.INVALID_EMAIL_ERROR);
     }
 
     @Test
     public void invalidNameTest() throws Exception {
-
         writeLogin(INVALID_CHARACTER_NAME, CHARACTER_PASSWORD, CLIENT_MAJOR, CLIENT_MINOR,
                 CLIENT_VERSION, "", CHARACTER_RACE, CHARACTER_GENDER, CHARACTER_ARCHETYPE,
                 CHARACTER_HEAD, CHARACTER_MAIL, CHARACTER_HOMELAND);
 
         packet.handle(inputBuffer, connection);
         verify(connection).send(errPacket.capture());
-        assertEquals(UserCharacterBuilder.INVALID_NAME_ERROR, errPacket.getValue().getMessage());
+        assertThat(errPacket.getValue().getMessage()).isEqualTo(UserCharacterBuilder.INVALID_NAME_ERROR);
     }
 
     @Test
@@ -118,9 +116,9 @@ public class LoginNewCharacterPacketTest {
         verify((ConnectedUser) connection.getUser()).setAccount(capture.capture());
         final Account account = capture.getValue();
 
-        assertTrue(account.hasCharacter(CHARACTER_NAME));
-        assertEquals(account.getName(), CHARACTER_NAME);
-        assertEquals(account.getMail(), CHARACTER_MAIL);
+        assertThat(account.hasCharacter(CHARACTER_NAME)).isTrue();
+        assertThat(account.getName()).isEqualTo(CHARACTER_NAME);
+        assertThat(account.getMail()).isEqualTo(CHARACTER_MAIL);
 
         // TODO Check if the charfile was created.
     }
@@ -136,7 +134,7 @@ public class LoginNewCharacterPacketTest {
 
         packet.handle(inputBuffer, connection);
         verify(connection).send(errPacket.capture());
-        assertEquals(String.format(LoginServiceImpl.CLIENT_OUT_OF_DATE_ERROR_FORMAT, CLIENT_MAJOR + "." + CLIENT_MINOR + "." + CLIENT_VERSION), errPacket.getValue().getMessage());
+        assertThat(errPacket.getValue().getMessage()).isEqualTo(String.format(LoginServiceImpl.CLIENT_OUT_OF_DATE_ERROR_FORMAT, CLIENT_MAJOR + "." + CLIENT_MINOR + "." + CLIENT_VERSION));
     }
 
     @Test
@@ -149,7 +147,7 @@ public class LoginNewCharacterPacketTest {
 
         packet.handle(inputBuffer, connection);
         verify(connection).send(errPacket.capture());
-        assertEquals(LoginServiceImpl.ACCOUNT_NAME_TAKEN_ERROR, errPacket.getValue().getMessage());
+        assertThat(errPacket.getValue().getMessage()).isEqualTo(LoginServiceImpl.ACCOUNT_NAME_TAKEN_ERROR);
     }
 
     @Test
@@ -163,7 +161,7 @@ public class LoginNewCharacterPacketTest {
 
         packet.handle(inputBuffer, connection);
         verify(connection).send(errPacket.capture());
-        assertEquals(LoginServiceImpl.MUST_THROW_DICES_BEFORE_ERROR, errPacket.getValue().getMessage());
+        assertThat(errPacket.getValue().getMessage()).isEqualTo(LoginServiceImpl.MUST_THROW_DICES_BEFORE_ERROR);
     }
 
     @Test
@@ -174,7 +172,7 @@ public class LoginNewCharacterPacketTest {
 
         packet.handle(inputBuffer, connection);
         verify(connection).send(errPacket.capture());
-        assertEquals(LoginServiceImpl.INVALID_RACE_ERROR, errPacket.getValue().getMessage());
+        assertThat(errPacket.getValue().getMessage()).isEqualTo(LoginServiceImpl.INVALID_RACE_ERROR);
     }
 
     @Test
@@ -185,7 +183,7 @@ public class LoginNewCharacterPacketTest {
 
         packet.handle(inputBuffer, connection);
         verify(connection).send(errPacket.capture());
-        assertEquals(LoginServiceImpl.INVALID_GENDER_ERROR, errPacket.getValue().getMessage());
+        assertThat(errPacket.getValue().getMessage()).isEqualTo(LoginServiceImpl.INVALID_GENDER_ERROR);
     }
 
     @Test
@@ -196,7 +194,7 @@ public class LoginNewCharacterPacketTest {
 
         packet.handle(inputBuffer, connection);
         verify(connection).send(errPacket.capture());
-        assertEquals(LoginServiceImpl.INVALID_HEAD_ERROR, errPacket.getValue().getMessage());
+        assertThat(errPacket.getValue().getMessage()).isEqualTo(LoginServiceImpl.INVALID_HEAD_ERROR);
     }
 
     @Test
@@ -207,7 +205,7 @@ public class LoginNewCharacterPacketTest {
 
         packet.handle(inputBuffer, connection);
         verify(connection).send(errPacket.capture());
-        assertEquals(LoginServiceImpl.INVALID_ARCHETYPE_ERROR, errPacket.getValue().getMessage());
+        assertThat(errPacket.getValue().getMessage()).isEqualTo(LoginServiceImpl.INVALID_ARCHETYPE_ERROR);
     }
 
     @Test
@@ -220,7 +218,7 @@ public class LoginNewCharacterPacketTest {
 
         packet.handle(inputBuffer, connection);
         verify(connection).send(errPacket.capture());
-        assertEquals(LoginServiceImpl.CHARACTER_CREATION_DISABLED_ERROR, errPacket.getValue().getMessage());
+        assertThat(errPacket.getValue().getMessage()).isEqualTo(LoginServiceImpl.CHARACTER_CREATION_DISABLED_ERROR);
     }
 
     @Test
@@ -233,7 +231,7 @@ public class LoginNewCharacterPacketTest {
 
         packet.handle(inputBuffer, connection);
         verify(connection).send(errPacket.capture());
-        assertEquals(LoginServiceImpl.ONLY_ADMINS_ERROR, errPacket.getValue().getMessage());
+        assertThat(errPacket.getValue().getMessage()).isEqualTo(LoginServiceImpl.ONLY_ADMINS_ERROR);
     }
 
     private void writeLogin(final String charName, final String password, final byte major,

--- a/server/src/test/java/com/ao/service/CharacterBodyServiceTest.java
+++ b/server/src/test/java/com/ao/service/CharacterBodyServiceTest.java
@@ -3,12 +3,12 @@ package com.ao.service;
 import com.ao.model.character.Gender;
 import com.ao.model.character.Race;
 import com.ao.utils.RangeParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CharacterBodyServiceTest {
 
@@ -23,29 +23,29 @@ public class CharacterBodyServiceTest {
     private static final int VALID_GNOME_FEMALE_HEAD = 470;
     private static final int VALID_HUMAN_MALE_HEAD = 1;
     private static final int VALID_HUMAN_FEMALE_HEAD = 70;
+    private final List<Integer> headsDarkelfMale = RangeParser.parseIntegers("201-221");
+    private final List<Integer> headsDarkelfFemale = RangeParser.parseIntegers("270-288");
+    private final List<Integer> headsDwarfMale = RangeParser.parseIntegers("301-319");
+    private final List<Integer> headsDwarfFemale = RangeParser.parseIntegers("370-384");
+    private final List<Integer> headsElfMale = RangeParser.parseIntegers("101-122");
+    private final List<Integer> headsElfFemale = RangeParser.parseIntegers("170-188");
+    private final List<Integer> headsGnomeMale = RangeParser.parseIntegers("401-416");
+    private final List<Integer> headsGnomeFemale = RangeParser.parseIntegers("470-484");
+    private final List<Integer> headsHumanMale = RangeParser.parseIntegers("1-40");
+    private final List<Integer> headsHumanFemale = RangeParser.parseIntegers("70-89");
+    private final int darkelfMaleBody = 3;
+    private final int darkelfFemaleBody = 4;
+    private final int dwarfMaleBody = 300;
+    private final int dwarfFemaleBody = 301;
+    private final int elfMaleBody = 2;
+    private final int elfFemaleBody = 5;
+    private final int gnomeMaleBody = 302;
+    private final int gnomeFemaleBody = 303;
+    private final int humanMaleBody = 1;
+    private final int humanFemaleBody = 6;
     protected CharacterBodyService characterBodyService;
-    private List<Integer> headsDarkelfMale = RangeParser.parseIntegers("201-221");
-    private List<Integer> headsDarkelfFemale = RangeParser.parseIntegers("270-288");
-    private List<Integer> headsDwarfMale = RangeParser.parseIntegers("301-319");
-    private List<Integer> headsDwarfFemale = RangeParser.parseIntegers("370-384");
-    private List<Integer> headsElfMale = RangeParser.parseIntegers("101-122");
-    private List<Integer> headsElfFemale = RangeParser.parseIntegers("170-188");
-    private List<Integer> headsGnomeMale = RangeParser.parseIntegers("401-416");
-    private List<Integer> headsGnomeFemale = RangeParser.parseIntegers("470-484");
-    private List<Integer> headsHumanMale = RangeParser.parseIntegers("1-40");
-    private List<Integer> headsHumanFemale = RangeParser.parseIntegers("70-89");
-    private int darkelfMaleBody = 3;
-    private int darkelfFemaleBody = 4;
-    private int dwarfMaleBody = 300;
-    private int dwarfFemaleBody = 301;
-    private int elfMaleBody = 2;
-    private int elfFemaleBody = 5;
-    private int gnomeMaleBody = 302;
-    private int gnomeFemaleBody = 303;
-    private int humanMaleBody = 1;
-    private int humanFemaleBody = 6;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         characterBodyService = new CharacterBodyServiceImpl(headsDarkelfMale, headsDarkelfFemale,
                 headsDwarfMale, headsDwarfFemale, headsElfMale, headsElfFemale, headsGnomeMale,
@@ -56,61 +56,49 @@ public class CharacterBodyServiceTest {
 
     @Test
     public void testValidHead() {
-        assertFalse(characterBodyService.isValidHead(INVALID_HEAD, Race.DARK_ELF, Gender.MALE));
-        assertTrue(characterBodyService.isValidHead(VALID_DARKELF_MALE_HEAD, Race.DARK_ELF, Gender.MALE));
+        assertThat(characterBodyService.isValidHead(INVALID_HEAD, Race.DARK_ELF, Gender.MALE)).isFalse();
+        assertThat(characterBodyService.isValidHead(VALID_DARKELF_MALE_HEAD, Race.DARK_ELF, Gender.MALE)).isTrue();
 
-        assertFalse(characterBodyService.isValidHead(INVALID_HEAD, Race.DARK_ELF, Gender.FEMALE));
-        assertTrue(characterBodyService.isValidHead(VALID_DARKELF_FEMALE_HEAD, Race.DARK_ELF, Gender.FEMALE));
+        assertThat(characterBodyService.isValidHead(INVALID_HEAD, Race.DARK_ELF, Gender.FEMALE)).isFalse();
+        assertThat(characterBodyService.isValidHead(VALID_DARKELF_FEMALE_HEAD, Race.DARK_ELF, Gender.FEMALE)).isTrue();
 
+        assertThat(characterBodyService.isValidHead(INVALID_HEAD, Race.DWARF, Gender.MALE)).isFalse();
+        assertThat(characterBodyService.isValidHead(VALID_DWARF_MALE_HEAD, Race.DWARF, Gender.MALE)).isTrue();
 
-        assertFalse(characterBodyService.isValidHead(INVALID_HEAD, Race.DWARF, Gender.MALE));
-        assertTrue(characterBodyService.isValidHead(VALID_DWARF_MALE_HEAD, Race.DWARF, Gender.MALE));
+        assertThat(characterBodyService.isValidHead(INVALID_HEAD, Race.DWARF, Gender.FEMALE)).isFalse();
+        assertThat(characterBodyService.isValidHead(VALID_DWARF_FEMALE_HEAD, Race.DWARF, Gender.FEMALE)).isTrue();
 
-        assertFalse(characterBodyService.isValidHead(INVALID_HEAD, Race.DWARF, Gender.FEMALE));
-        assertTrue(characterBodyService.isValidHead(VALID_DWARF_FEMALE_HEAD, Race.DWARF, Gender.FEMALE));
+        assertThat(characterBodyService.isValidHead(INVALID_HEAD, Race.ELF, Gender.MALE)).isFalse();
+        assertThat(characterBodyService.isValidHead(VALID_ELF_MALE_HEAD, Race.ELF, Gender.MALE)).isTrue();
 
+        assertThat(characterBodyService.isValidHead(INVALID_HEAD, Race.ELF, Gender.FEMALE)).isFalse();
+        assertThat(characterBodyService.isValidHead(VALID_ELF_FEMALE_HEAD, Race.ELF, Gender.FEMALE)).isTrue();
 
-        assertFalse(characterBodyService.isValidHead(INVALID_HEAD, Race.ELF, Gender.MALE));
-        assertTrue(characterBodyService.isValidHead(VALID_ELF_MALE_HEAD, Race.ELF, Gender.MALE));
+        assertThat(characterBodyService.isValidHead(INVALID_HEAD, Race.GNOME, Gender.MALE)).isFalse();
+        assertThat(characterBodyService.isValidHead(VALID_GNOME_MALE_HEAD, Race.GNOME, Gender.MALE)).isTrue();
 
-        assertFalse(characterBodyService.isValidHead(INVALID_HEAD, Race.ELF, Gender.FEMALE));
-        assertTrue(characterBodyService.isValidHead(VALID_ELF_FEMALE_HEAD, Race.ELF, Gender.FEMALE));
+        assertThat(characterBodyService.isValidHead(INVALID_HEAD, Race.GNOME, Gender.FEMALE)).isFalse();
+        assertThat(characterBodyService.isValidHead(VALID_GNOME_FEMALE_HEAD, Race.GNOME, Gender.FEMALE)).isTrue();
 
+        assertThat(characterBodyService.isValidHead(INVALID_HEAD, Race.HUMAN, Gender.MALE)).isFalse();
+        assertThat(characterBodyService.isValidHead(VALID_HUMAN_MALE_HEAD, Race.HUMAN, Gender.MALE)).isTrue();
 
-        assertFalse(characterBodyService.isValidHead(INVALID_HEAD, Race.GNOME, Gender.MALE));
-        assertTrue(characterBodyService.isValidHead(VALID_GNOME_MALE_HEAD, Race.GNOME, Gender.MALE));
-
-        assertFalse(characterBodyService.isValidHead(INVALID_HEAD, Race.GNOME, Gender.FEMALE));
-        assertTrue(characterBodyService.isValidHead(VALID_GNOME_FEMALE_HEAD, Race.GNOME, Gender.FEMALE));
-
-
-        assertFalse(characterBodyService.isValidHead(INVALID_HEAD, Race.HUMAN, Gender.MALE));
-        assertTrue(characterBodyService.isValidHead(VALID_HUMAN_MALE_HEAD, Race.HUMAN, Gender.MALE));
-
-        assertFalse(characterBodyService.isValidHead(INVALID_HEAD, Race.HUMAN, Gender.FEMALE));
-        assertTrue(characterBodyService.isValidHead(VALID_HUMAN_FEMALE_HEAD, Race.HUMAN, Gender.FEMALE));
+        assertThat(characterBodyService.isValidHead(INVALID_HEAD, Race.HUMAN, Gender.FEMALE)).isFalse();
+        assertThat(characterBodyService.isValidHead(VALID_HUMAN_FEMALE_HEAD, Race.HUMAN, Gender.FEMALE)).isTrue();
     }
 
     @Test
     public void GetBody() {
-        assertEquals(darkelfMaleBody, characterBodyService.getBody(Race.DARK_ELF, Gender.MALE));
-
-        assertEquals(darkelfFemaleBody, characterBodyService.getBody(Race.DARK_ELF, Gender.FEMALE));
-
-        assertEquals(dwarfMaleBody, characterBodyService.getBody(Race.DWARF, Gender.MALE));
-
-        assertEquals(dwarfFemaleBody, characterBodyService.getBody(Race.DWARF, Gender.FEMALE));
-
-        assertEquals(elfMaleBody, characterBodyService.getBody(Race.ELF, Gender.MALE));
-
-        assertEquals(elfFemaleBody, characterBodyService.getBody(Race.ELF, Gender.FEMALE));
-
-        assertEquals(gnomeMaleBody, characterBodyService.getBody(Race.GNOME, Gender.MALE));
-
-        assertEquals(gnomeFemaleBody, characterBodyService.getBody(Race.GNOME, Gender.FEMALE));
-
-        assertEquals(humanMaleBody, characterBodyService.getBody(Race.HUMAN, Gender.MALE));
-
-        assertEquals(humanFemaleBody, characterBodyService.getBody(Race.HUMAN, Gender.FEMALE));
+        assertThat(characterBodyService.getBody(Race.DARK_ELF, Gender.MALE)).isEqualTo(darkelfMaleBody);
+        assertThat(characterBodyService.getBody(Race.DARK_ELF, Gender.FEMALE)).isEqualTo(darkelfFemaleBody);
+        assertThat(characterBodyService.getBody(Race.DWARF, Gender.MALE)).isEqualTo(dwarfMaleBody);
+        assertThat(characterBodyService.getBody(Race.DWARF, Gender.FEMALE)).isEqualTo(dwarfFemaleBody);
+        assertThat(characterBodyService.getBody(Race.ELF, Gender.MALE)).isEqualTo(elfMaleBody);
+        assertThat(characterBodyService.getBody(Race.ELF, Gender.FEMALE)).isEqualTo(elfFemaleBody);
+        assertThat(characterBodyService.getBody(Race.GNOME, Gender.MALE)).isEqualTo(gnomeMaleBody);
+        assertThat(characterBodyService.getBody(Race.GNOME, Gender.FEMALE)).isEqualTo(gnomeFemaleBody);
+        assertThat(characterBodyService.getBody(Race.HUMAN, Gender.MALE)).isEqualTo(humanMaleBody);
+        assertThat(characterBodyService.getBody(Race.HUMAN, Gender.FEMALE)).isEqualTo(humanFemaleBody);
     }
+
 }

--- a/server/src/test/java/com/ao/service/map/MapServiceImplTest.java
+++ b/server/src/test/java/com/ao/service/map/MapServiceImplTest.java
@@ -5,9 +5,9 @@ import com.ao.data.dao.WorldMapDAO;
 import com.ao.model.map.Tile;
 import com.ao.model.map.WorldMap;
 import com.ao.service.MapService;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -34,8 +34,7 @@ public class MapServiceImplTest {
 
         final MapService service = new MapServiceImpl(dao, cityDao, areaService);
         service.loadMaps();
-
-        assertSame(map, service.getMap(mapId));
+        assertThat(service.getMap(mapId)).isSameAs(map);
     }
 
 }

--- a/server/src/test/java/com/ao/service/timedevents/AbstractTimedEventTest.java
+++ b/server/src/test/java/com/ao/service/timedevents/AbstractTimedEventTest.java
@@ -2,7 +2,7 @@ package com.ao.service.timedevents;
 
 import com.ao.model.character.Character;
 import com.ao.service.TimedEventsService;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -32,4 +32,5 @@ public abstract class AbstractTimedEventTest {
 
         verify(service).addEvent(any(Character.class), event, anyLong(), anyLong(), anyLong());
     }
+
 }

--- a/server/src/test/java/com/ao/service/timedevents/TimedEventsServiceImplTest.java
+++ b/server/src/test/java/com/ao/service/timedevents/TimedEventsServiceImplTest.java
@@ -2,8 +2,8 @@ package com.ao.service.timedevents;
 
 import com.ao.mock.MockFactory;
 import com.ao.model.character.Character;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.*;
 
@@ -12,7 +12,7 @@ public class TimedEventsServiceImplTest {
     private TimedEvent event;
     private TimedEventsServiceImpl service;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         service = new TimedEventsServiceImpl();
     }

--- a/server/src/test/java/com/ao/service/timedevents/TimedEventsServiceImplTest.java
+++ b/server/src/test/java/com/ao/service/timedevents/TimedEventsServiceImplTest.java
@@ -52,17 +52,18 @@ public class TimedEventsServiceImplTest {
 
         event = MockFactory.mockTimedEvent(chara);
 
-        service.addEvent(chara, event, 50L, 50L, 300L);
-        service.addEvent(chara, event2, 100L);
-        service.addEvent(chara, event3, 200L);
+        service.addEvent(chara, event, 30L, 30L, 300L); // Ejecuta cada 30ms
+        service.addEvent(chara, event2, 150L);          // Ejecuta a los 150ms
+        service.addEvent(chara, event3, 250L);          // Ejecuta a los 250ms
 
-        // Let the first event execute and then stop its repetition.
-        Thread.sleep(55L);
+        // Espera tiempo suficiente para que el primer evento se ejecute varias veces pero antes de que event2 y event3 tengan oportunidad
+        Thread.sleep(100L); // event se ejecuta a 30ms, 60ms, 90ms
 
         service.removeCharacterEvents(chara);
 
-        verify(event).execute();
-        // These hadn't got time to execute
+        // El primer evento debería haberse ejecutado al menos 3 veces
+        verify(event, atLeast(2)).execute();
+        // Estos no deberian haberse ejecutado (cancelados antes de tiempo)
         verifyNoInteractions(event2, event3);
     }
 

--- a/server/src/test/resources/test.properties
+++ b/server/src/test/resources/test.properties
@@ -1,3 +1,39 @@
-# Override some defaults from project.properties
-config.path.server=src/test/resources/Server.ini
+# Archivos de configuracion desde classpath
+# Creo que es innecesario este archivo, ya que ahora los recursos se leen desde el classpath, por lo tanto creo que el
+# archivo project.properties es suficiente
+config.path.server=Server.ini
+config.path.archetype=Dat/Balance.dat
 config.path.charfiles=src/test/resources/charfiles/
+config.path.maps=Maps/
+config.path.objsdat=Dat/obj.dat
+config.path.npcsdat=Dat/NPCs.dat
+config.maps.amount=290
+config.path.citiesdat=Dat/Ciudades.dat
+# Configuracion de seguridad
+config.security.manager=com.ao.security.impl.DefaultSecurityManager
+# Configuracion del servicio de login
+config.loginservice.initialavailableskills=10
+# Configuracion de inventario
+config.inventory.itemperrow=5
+# Configuracion de heads para razas
+config.heads.darkelf.male=201-221
+config.heads.darkelf.female=270-288
+config.heads.dwarf.male=301-319
+config.heads.dwarf.female=370-384
+config.heads.elf.male=101-122
+config.heads.elf.female=170-188
+config.heads.gnome.male=401-416
+config.heads.gnome.female=470-484
+config.heads.human.male=1-40
+config.heads.human.female=70-89
+# Configuracion de bodies para razas
+config.bodies.darkelf.male=3
+config.bodies.darkelf.female=3
+config.bodies.dwarf.male=300
+config.bodies.dwarf.female=300
+config.bodies.elf.male=2
+config.bodies.elf.female=2
+config.bodies.gnome.male=300
+config.bodies.gnome.female=300
+config.bodies.human.male=1
+config.bodies.human.female=1

--- a/server/src/test/resources/test.properties
+++ b/server/src/test/resources/test.properties
@@ -3,7 +3,7 @@
 # archivo project.properties es suficiente
 config.path.server=Server.ini
 config.path.archetype=Dat/Balance.dat
-config.path.charfiles=src/test/resources/charfiles/
+config.path.charfiles=data/charfiles/
 config.path.maps=Maps/
 config.path.objsdat=Dat/obj.dat
 config.path.npcsdat=Dat/NPCs.dat


### PR DESCRIPTION
Complete migration to JUnit 5. Also, the use of JUnit and Hamcrest asserts was replaced by the AssertJ library.

Some unit tests have been fixed and resources are now loaded from the classpath.